### PR TITLE
Spring 4, javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,14 +190,14 @@ You can download the source from this repo and run
 ```
 Run UnRAVL as:
 ```bash
-    bin/unravl.sh script.json  # from Linux
-    bin\unravl.bat script.json # from Windows
+    bin/unravl.sh src/test/scripts/hello.json  # from Linux
+    bin\unravl.bat src/test/scripts/hello.json # from Windows
 ```
 
 Alternatively, you can download the binary release.
 Create a directory `unravl` for your local copy of UnRAVL, `cd unravl` to that directory,
 then download the release [unravl-0.2.0.zip](https://github.com/sassoftware/unravl/releases/download/v0.2.0/unravl-0.2.0.zip). Unzip the release file in the `unravl` directory.
-Then run UnRAVL using the scripts in the `bin` directory, as described above
+Then run UnRAVL using the scripts in the `bin` directory, as described above.
 
 ## Contributing
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,18 +8,18 @@ version = '0.2.1-SNAPSHOT'
 description = "Uniform REST API Validation Language"
 
 ext {
-	jacksonVersion = "2.2.3"
-	groovyVersion = "2.3.7"
-	springVersion = "3.2.11.RELEASE"
-	httpClientVersion = "4.3.6"
-	httpCoreVersion = "4.3.3"
-	commonsCodecVersion = "1.9"
-	log4jVersion = "1.2.16"
-	guavaVersion = "17.0"
-	junitVersion = "4.8.1"
-    	jsonSchemaValidatorVersion = "2.2.6"
-    	jsonSchemaCoreVersion = "1.2.5"
-    	jacksonCoreUtilsVersion = "1.8"
+	jacksonVersion = "2.+"
+	groovyVersion = "2.+"
+	springVersion = "4.+"
+	httpClientVersion = "4.+"
+	httpCoreVersion = "4.+"
+	commonsCodecVersion = "1.+"
+	log4jVersion = "1.+"
+	guavaVersion = "18.+"
+	junitVersion = "4.+"
+    jsonSchemaValidatorVersion = "2.+"
+    jsonSchemaCoreVersion = "1.+"
+    jacksonCoreUtilsVersion = "1.+"
 }
 
 sourceCompatibility = 1.6
@@ -36,9 +36,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: jacksonVersion
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
-    compile group: 'com.github.fge', name: 'json-schema-validator', version: jsonSchemaValidatorVersion
-    compile group: 'com.github.fge', name: 'json-schema-core', version: jsonSchemaCoreVersion
-    compile group: 'com.github.fge', name: 'jackson-coreutils', version: jacksonCoreUtilsVersion
+    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: jacksonVersion
     compile group: 'org.codehaus.groovy', name: 'groovy-bsf', version: groovyVersion
     compile group: 'org.springframework', name: 'spring-core', version: springVersion
     compile group: 'org.springframework', name: 'spring-web', version: springVersion
@@ -49,7 +47,9 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: guavaVersion
     // Note: junit is an intentional runtime dependency, not just testCompile
     compile group: 'junit', name: 'junit', version: junitVersion
-    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: jacksonVersion
+    compile group: 'com.github.fge', name: 'json-schema-validator', version: jsonSchemaValidatorVersion
+    compile group: 'com.github.fge', name: 'json-schema-core', version: jsonSchemaCoreVersion
+    compile group: 'com.github.fge', name: 'jackson-coreutils', version: jacksonCoreUtilsVersion
 }
 
 task copyDeps(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -56,3 +56,9 @@ task copyDeps(type: Copy) {
     into "$buildDir/output/lib"
     from configurations.runtime
 }
+
+
+javadoc {
+     source = sourceSets.main.allJava
+     classpath = configurations.compile
+}

--- a/build.gradle
+++ b/build.gradle
@@ -8,22 +8,22 @@ version = '0.2.1-SNAPSHOT'
 description = "Uniform REST API Validation Language"
 
 ext {
-	jacksonVersion = "2.+"
-	groovyVersion = "2.+"
-	springVersion = "4.+"
-	httpClientVersion = "4.+"
-	httpCoreVersion = "4.+"
-	commonsCodecVersion = "1.+"
-	log4jVersion = "1.+"
-	guavaVersion = "18.+"
-	junitVersion = "4.+"
-    jsonSchemaValidatorVersion = "2.+"
-    jsonSchemaCoreVersion = "1.+"
-    jacksonCoreUtilsVersion = "1.+"
+	jacksonVersion = "2.5.+"
+	groovyVersion = "2.4.3"
+	springVersion = "4.1.6.RELEASE"
+	httpClientVersion = "4.5"
+	httpCoreVersion = "4.4.1"
+	commonsCodecVersion = "1.10"
+	log4jVersion = "1.2.17"
+	guavaVersion = "18.0"
+	junitVersion = "4.12"
+    jsonSchemaValidatorVersion = "2.2.6"
+    jsonSchemaCoreVersion = "1.2.5"
+    jacksonCoreUtilsVersion = "1.8"
 }
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 repositories {
        maven { url "https://repo1.maven.org/maven2/" }

--- a/src/main/java/com/sas/unravl/ApiCall.java
+++ b/src/main/java/com/sas/unravl/ApiCall.java
@@ -83,7 +83,7 @@ public class ApiCall {
     private static final ObjectNode STATUS_ASSERTION = new ObjectNode(
             JsonNodeFactory.instance);
     static {
-        STATUS_ASSERTION.put("status", new TextNode("2.."));
+        STATUS_ASSERTION.set("status", new TextNode("2.."));
     }
 
     public ApiCall(UnRAVL script) throws UnRAVLException, IOException {
@@ -233,7 +233,7 @@ public class ApiCall {
 
         if (bgClass == null || body.isArray() || body.isTextual()) {
             bodyObj = new ObjectNode(JsonNodeFactory.instance);
-            bodyObj.put(JSON_GENERATOR_KEY, body);
+            bodyObj.set(JSON_GENERATOR_KEY, body);
             generatorKey = JSON_GENERATOR_KEY;
             bgClass = JsonRequestBodyGenerator.class;
         }
@@ -580,8 +580,8 @@ public class ApiCall {
      * Wrap exception in an UnRAVLException (unless it already is one), then
      * throw the UnRAVLException
      * 
-     * @param exception
-     * @throws UnRAVLException
+     * @param exception an exception
+     * @throws UnRAVLException the wrapped exception
      */
     public void throwException(Exception exception) throws UnRAVLException {
         if (exception instanceof UnRAVLException)

--- a/src/main/java/com/sas/unravl/BaseUnRAVLPlugin.java
+++ b/src/main/java/com/sas/unravl/BaseUnRAVLPlugin.java
@@ -14,10 +14,17 @@ public abstract class BaseUnRAVLPlugin implements UnRAVLPlugin {
     private ObjectNode scriptlet;
     private ApiCall call;
 
+    /**
+     * @return the API call that this plugin is processing
+     */
     public ApiCall getCall() {
         return call;
     }
 
+    /**
+     * Set the runtime API call instance
+     * @param call the current API call instance
+     */
     public void setCall(ApiCall call) {
         this.call = call;
     }

--- a/src/main/java/com/sas/unravl/Main.java
+++ b/src/main/java/com/sas/unravl/Main.java
@@ -6,9 +6,8 @@ import java.util.Properties;
 
 /**
  * The main command-line interface for running {@link UnRAVL} scripts. You can
- * run via <code>/u/sasdjb/bin/unravl</code> or
- * <code>\\\\dntsrc\\u\\sasdjb\\bin\\unravl</code>
- *
+ * run via <code>bin/unravl.sh</code> (Linux, Mac OS X) or <code>bin\\unravl.bat</code> (Windows)
+ * Below, <code>unravl</code> refers to the correct script for you environment
  * <pre>
  * unravl script-file [... script-file]
  * </pre>
@@ -18,25 +17,27 @@ import java.util.Properties;
  * a JSON array of UnRAVL scripts.
  * <p>
  * By default, unravl has a built-in Log4j configuration file, which has tracing
- * enabled for the com.sas.unravl package, but you can pass your own with
+ * enabled for the com.sas.unravl package, but you can pass your own 
+ * by setting UNRAVL_OPT:
  *
  * <pre>
- * java -Djog4j.configuration=mylog4j.properties -jar sas.unravl.jar script.json
+ * UNRAVL_OPT="-Djog4j.configuration=mylog4j.properties"  unravl script-file
  * </pre>
  *
- * You can also use this java invocation if you want to pass initial variable
- * bindings for the {@link UnRAVLRuntime} environment.
+ * You can also use this UNRAVL_OPT if you want to pass initial variable
+ * bindings for the {@link UnRAVLRuntime} environment. See the
+ * unravl.sh 
  *
  * <pre>
- * java -Dvar1=value1 -Dvar2=value2 -jar sas.unravl.jar script.json
+ * UNRAVL_OPT="-Dvar1=value1 -Dvar2=value2" unravl script.json
  * </pre>
  *
- * @author sasdjb
+ * @author David.Biesack@sas.com
  */
 public final class Main {
 
     /**
-     * Man entry point. Each arg is the name of an UnRAVL script file or URL All
+     * Man entry point. Each command line argument <em>script-file</em> is the name of an UnRAVL script file or URL. All
      * scripts will run in the same shared UnRAVLRuntime and thus share a common
      * environment and set of variables.
      */

--- a/src/main/java/com/sas/unravl/Main.java
+++ b/src/main/java/com/sas/unravl/Main.java
@@ -40,6 +40,7 @@ public final class Main {
      * Man entry point. Each command line argument <em>script-file</em> is the name of an UnRAVL script file or URL. All
      * scripts will run in the same shared UnRAVLRuntime and thus share a common
      * environment and set of variables.
+     * @param argv commmand line arguments
      */
     public static void main(String argv[]) {
         argv = preProcessArgs(argv);

--- a/src/main/java/com/sas/unravl/UnRAVLPlugin.java
+++ b/src/main/java/com/sas/unravl/UnRAVLPlugin.java
@@ -8,27 +8,39 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * and extractors. Each plugin contains the UnRAVL script and the
  * ObjectNodescriptlet that it executes. For example, the UnRAVL assertion to
  * test if a variable is bound in the current environment is expressed as
- * 
+ *
  * <pre>
  * { "bound" : "varName" }
  * </pre>
- * 
+ *
  * within an UnRAVL script's "preconditions" or "assert" member.
- * 
+ *
  * @author DavidBiesack@sas.com
  */
 public interface UnRAVLPlugin {
 
-    /** Get the scriptlet which defines/configures this instance */
+    /**
+     * Get the scriptlet that defines this assertion
+     * @return the scriptlet node
+     */
     public abstract ObjectNode getScriptlet();
 
-    /** Set the scriptlet which defines/configures this instance */
-    public abstract void setScriptlet(ObjectNode scriptlet);
+    /**
+     * Set the scriptlet that defines this assertion
+     * @param node the UnRAVL scriptlet node
+     */
+    public abstract void setScriptlet(ObjectNode node);
 
-    /** Set the UnRAVL script in which this plugin runs. */
+    /**
+     * Set the UnRAVL script that this instance is running in
+     * @param script the current UnRAVL script
+     */
     public abstract void setScript(UnRAVL script);
 
-    /** Get the UnRAVL script in which this plugin runs. */
+    /**
+     * Get the UnRAVL script in which this plugin runs.
+     * @return the current script this plugin is processing
+     */
     public abstract UnRAVL getScript();
 
 }

--- a/src/main/java/com/sas/unravl/annotations/UnRAVLAssertionPlugin.java
+++ b/src/main/java/com/sas/unravl/annotations/UnRAVLAssertionPlugin.java
@@ -11,34 +11,36 @@ import java.lang.annotation.Target;
  * with this class within "assert" or "precondition" elements of an UnRAVL
  * script. For example, the class com.sas.unravl.assertions.BoundAssertion uses
  * the annotation
- * 
+ *
  * <pre>
  * &#x40;UnRAVLAssertionPlugin("bound")
  * </pre>
- * 
+ *
  * so that UnRAVL scripts which use the "assert" (or "precondition") scriptlet
- * 
+ *
  * <pre>
  * "assert" : [
  *            { "bound" : "location" }
  * ]
  * </pre>
- * 
+ *
  * can execute that assertion by instantiating a BoundAssertion.
  * <p>
  * A single assertion class can register multiple keys, if it wishes to define
  * an alias or if it wants to support different behavior depending on the key.
  * com.sas.unravle.asssertions.GroovyAssertion uses
- * 
+ *
  * <pre>
  * &#x40;UnRAVLAssertionPlugin({"groovy","Groovy"})
  * </pre>
- * 
+ *
  * @author DavidBiesack@sas.com
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface UnRAVLAssertionPlugin {
-    /** The tag by which this plug in is named in UnRAVL scripts */
+    /** The tags by which this plugin is named in UnRAVL scripts
+        @return the plugin tags
+     */
     String[] value();
 }

--- a/src/main/java/com/sas/unravl/annotations/UnRAVLAuthPlugin.java
+++ b/src/main/java/com/sas/unravl/annotations/UnRAVLAuthPlugin.java
@@ -10,27 +10,29 @@ import java.lang.annotation.Target;
  * UnRAVLRuntime to associate one ore more string keys (the annotation value)
  * with this class within "auth" elements of an UnRAVL script. For example, the
  * class com.sas.unravl.auth.BasicAuth uses the annotation
- * 
+ *
  * <pre>
  * &#x40;UnRAVLAssertionPlugin("basic")
  * </pre>
- * 
+ *
  * so that UnRAVL scripts which use the "auth" scriptlet
- * 
+ *
  * <pre>
  * "auth" : { "basic" : "location" }
  * </pre>
- * 
+ *
  * will use Basic Authentication based on the credentials for the location
  * <p>
  * A single auth class can register multiple keys, if it wishes to define an
  * alias or if it wants to support different behavior depending on the key.
- * 
+ *
  * @author DavidBiesack@sas.com
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface UnRAVLAuthPlugin {
-    /** The tag by which this plug in is named in UnRAVL scripts */
+    /** The tags by which this plugin is named in UnRAVL scripts
+        @return the plugin tags
+     */
     String[] value();
 }

--- a/src/main/java/com/sas/unravl/annotations/UnRAVLExtractorPlugin.java
+++ b/src/main/java/com/sas/unravl/annotations/UnRAVLExtractorPlugin.java
@@ -10,26 +10,28 @@ import java.lang.annotation.Target;
  * UnRAVLRuntime to associate a string (the annotation value) with this class
  * within "extractor" element. For example, the class
  * com.sas.unravl.extractors.PatternExtractor uses the annotation
- * 
+ *
  * <pre>
  * &#x40;UnRAVLExtractorPlugin("pattern")
  * </pre>
- * 
+ *
  * so that UnRAVL scripts which use the extractor scriptlet
- * 
+ *
  * <pre>
  * "bind" [
  *        { "pattern" : [ "{location}", pattern, .... }
  * ]
  * </pre>
- * 
+ *
  * can execute that extractor by instantiating a PatternExtractor.
- * 
+ *
  * @author DavidBiesack@sas.com
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface UnRAVLExtractorPlugin {
-    /** The tag by which this plug in is named in UnRAVL scripts */
+    /** The tags by which this plugin is named in UnRAVL scripts
+        @return the plugin tags
+     */
     String[] value();
 }

--- a/src/main/java/com/sas/unravl/annotations/UnRAVLRequestBodyGeneratorPlugin.java
+++ b/src/main/java/com/sas/unravl/annotations/UnRAVLRequestBodyGeneratorPlugin.java
@@ -10,24 +10,26 @@ import java.lang.annotation.Target;
  * UnRAVLRuntime to associate a string (the annotation value) with this class
  * within "body" element. For example, the class
  * com.sas.unravl.generators.JsonRequestBodyGenerator uses the annotation
- * 
+ *
  * <pre>
  * &#x40;UnRAVLRequestBodyGeneratorPlugin("json")
  * </pre>
- * 
+ *
  * so that UnRAVL scripts which use the "body" scriptlet
- * 
+ *
  * <pre>
  * "body" : { "json" : { ... } }
  * </pre>
- * 
+ *
  * can execute that body generator by instantiating a JsonRequestBodyGenerator.
- * 
+ *
  * @author DavidBiesack@sas.com
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface UnRAVLRequestBodyGeneratorPlugin {
-    /** The tag by which this plug in is named in UnRAVL scripts */
+    /** The tags by which this plugin is named in UnRAVL scripts
+        @return the plugin tags
+     */
     String[] value();
 }

--- a/src/main/java/com/sas/unravl/assertions/BaseUnRAVLAssertion.java
+++ b/src/main/java/com/sas/unravl/assertions/BaseUnRAVLAssertion.java
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * 
  * is an assertion which uses the key "response". The assertion class is found
  * in the {@link UnRAVLPlugins} list of assertions and instantiated. Then, the
- * {@link #check(UnRAVL, JsonNode, Stage, ApiCall)} method is run, passing the
+ * {@link #check(UnRAVL, ObjectNode, Stage, ApiCall)} method is run, passing the
  * currently executing {@link UnRAVL} script and the JsonNode element that
  * defines the assertion scriptlet.
  * <p>

--- a/src/main/java/com/sas/unravl/assertions/GroovyAssertion.java
+++ b/src/main/java/com/sas/unravl/assertions/GroovyAssertion.java
@@ -100,7 +100,7 @@ public class GroovyAssertion extends BaseUnRAVLAssertion {
 
     public static ObjectNode assertionScriptlet(TextNode scriptlet) {
         ObjectNode o = new ObjectNode(JsonNodeFactory.instance);
-        o.put("groovy", scriptlet);
+        o.set("groovy", scriptlet);
         return o;
     }
 }

--- a/src/main/java/com/sas/unravl/assertions/JUnitWrapper.java
+++ b/src/main/java/com/sas/unravl/assertions/JUnitWrapper.java
@@ -21,7 +21,7 @@ import org.apache.log4j.Logger;
  * A convenience class for running UnRAVL scripts within a JUnit environment.
  * {@link UnRAVLException}s (including {@link UnRAVLAssertionException}s) are
  * wrapped in {#link AssertionErrors}.
- * 
+ *
  * @author DavidBiesack@sas.com
  */
 public class JUnitWrapper {
@@ -43,7 +43,6 @@ public class JUnitWrapper {
      * THis will try to run all scripts, even if some fail.
      * @param map initial environment
      * @param directoryName directory where scripts should be found
-     * @throws UnRAVLException if one or more scripts fail.
      */
     public static void runScriptsInDirectory(Map<String, Object> map,
             String directoryName) {
@@ -57,7 +56,6 @@ public class JUnitWrapper {
      * @param map initial environment
      * @param directoryName directory where scripts should be found
      * @param pattern Only run scripts whose name match this file name pattern.
-     * @throws UnRAVLException if one or more scripts fail.
      */
     public static void runScriptsInDirectory(Map<String, Object> map,
             String directoryName, final String pattern) {
@@ -84,11 +82,11 @@ public class JUnitWrapper {
      * environments modified by each script is discarded). This method asserts
      * that each script has no assertion failures. Run each script,
      * even if earlier ones had failures.
-     * 
+     *
      * @param env
      *            The initial environment to pass to each.
      * @param scriptFileNames an array of script file names to run.
-     * @throws UnRAVLException
+     * @return number of scripts which ran
      */
     public static int runScriptFiles(Map<String, Object> env,
             String... scriptFileNames) {
@@ -131,10 +129,11 @@ public class JUnitWrapper {
     /**
      * Run all scripts in the directory, but expect an UnRAVLException. This
      * should be used to test invalid scripts.
-     * 
+     *
      * TODO: Add boolean recursive option
      *
-     * @param directoryName
+     * @param env Additional variable bindings
+     * @param directoryName directory to scan for scripts
      */
     public static void tryScriptsInDirectory(Map<String, Object> env,
             String directoryName) {
@@ -164,8 +163,9 @@ public class JUnitWrapper {
     /**
      * Run a set of script files, but expect an UnRAVLException. This should be
      * used to test invalid scripts
-     * 
-     * @throws UnRAVLException
+     * @param env Additional variable bindings
+     * @param scriptFileNames script file names to scan for scripts
+     * @return the number of scripts which ran
      */
     public static int tryScriptFiles(Map<String, Object> env,
             String... scriptFileNames) {

--- a/src/main/java/com/sas/unravl/assertions/StatusAssertion.java
+++ b/src/main/java/com/sas/unravl/assertions/StatusAssertion.java
@@ -11,29 +11,32 @@ import com.sas.unravl.util.Json;
 /**
  * StatusAssertion asserts that the API call returned an HTTP status code that
  * matches the specification. There are three possible forms for this assertion:
- * 
+ *
  * <pre>
  * { "status" : int }
  * { "status" : [ int, int, ..., int ] }
  * { "status" : "<em>pattern</em>" }
  * </pre>
- * 
- * In the first form, the status must match the given int value exactly. <br/>
- * Example: <code>{ "status" : 200 }<code>
+ *
+ * In the first form, the status must match the given int value exactly. <br>
+ * Example: <code>{ "status" : 200 }</code>
  * <p>
  * In the second, the HTTP status code must match one of the int values.
  * The int values must be greater than or equal to 100 and
- * less than 600. 
- * <br/>Example: <code>{ "status" : 200, 201, 204 }<code>
+ * less than 600.
+ * <br>Example: <code>{ "status" : 200, 201, 204 }</code>
+ * </p>
  * <p>
  * In the third, the string representation of the status code must regular expression pattern.
- * This is the "default" assertion. 
- * <br/>Example: <code>{ "status" : "2.." }<code>
+ * This is the "default" assertion.
+ * <br>Example: <code>{ "status" : "2.." }</code>
+ * </p>
  * <p>
  * If an UnRAVL script has no "status" assertion, an implicit
- * assertion of <br/><code>{ "status" : "2.." }<code><br/>is applied,  which matches all 200-level
+ * assertion of <br><code>{ "status" : "2.." }</code><br>is applied, which matches all 200-level
  * status codes.
- * 
+ * </p>
+ *
  * @author David.Biesack@sas.com
  *
  */

--- a/src/main/java/com/sas/unravl/assertions/UnRAVLAssertion.java
+++ b/src/main/java/com/sas/unravl/assertions/UnRAVLAssertion.java
@@ -13,11 +13,11 @@ import com.sas.unravl.UnRAVLPlugins;
  * {@link UnRAVL} script will load UnRAVLAssertion objects while executing the
  * "preconditions" or "assert" members of the script. The first field in the
  * assertion member is used as the key, i.e.
- * 
+ *
  * <pre>
  * { "headers" : specification }
  * </pre>
- * 
+ *
  * is a headers assertion which uses the key "headers". The assertion class is
  * found in the {@link UnRAVLPlugins} list of assertions, and instantiated.
  * Then, the {@link #check(UnRAVL, ObjectNode, Stage, ApiCall)} method is run,
@@ -27,7 +27,7 @@ import com.sas.unravl.UnRAVLPlugins;
  * <p>
  * Assertions should extend {@link BaseUnRAVLAssertion} and their check() method
  * should invoke super.check(script,node)
- * 
+ *
  * @author David.Biesack@sas.com
  */
 public interface UnRAVLAssertion {
@@ -41,7 +41,7 @@ public interface UnRAVLAssertion {
 
     /**
      * execute the assertion within the given script
-     * 
+     *
      * @param script
      *            the currently running script
      * @param assertion
@@ -61,36 +61,51 @@ public interface UnRAVLAssertion {
     /**
      * Return the UnRAVLAssertionException, if running this assertion had an
      * exception
+     * @return a caught assertion exception
      */
     public UnRAVLAssertionException getUnRAVLAssertionException();
 
     /**
      * Set the UnRAVLAssertionException, if running this assertion had an
      * exception
+     * @param e an exception
      */
     public void setUnRAVLAssertionException(UnRAVLAssertionException e);
 
-    /** Set the scriptlet that defines this assertion */
+    /**
+     * Set the scriptlet that defines this assertion
+     * @param node the current node this assertion is processing
+     */
     public void setAssertion(ObjectNode node);
 
-    /** Get the scriptlet that defines this assertion */
+    /**
+     * Get the scriptlet that defines this assertion
+     * @return the current assertion element scirptlet
+     */
     public ObjectNode getAssertion();
 
-    /** Set the UnRAVL script that this instance is running in */
+    /**
+     * Set the UnRAVL script that this instance is running in
+     * @param script the current UnRAVL script
+     */
     public void setScript(UnRAVL script);
 
-    /** Set the UnRAVL script that this instance is running in */
+    /**
+     * Get the UnRAVL script that this instance is running in
+     * @return the script object
+     */
     public UnRAVL getScript();
 
     /**
-     * Set the UnRAVL stage (Precondition, assert) that this instance is running
+     * Set the UnRAVL stage (PRECONDITIONS, ASSERT) that this instance is running
      * in
+     * @param stage which ssertion stage this instance is running in
      */
     public void setStage(Stage stage);
 
     /**
-     * Get the UnRAVL stage (Precondition, assert) that this instance is running
-     * in
+     * @return the UnRAVL stage (PRECONDITIONS, ASSERT) that this instance is running
+     * in.
      */
     public Stage getStage();
 }

--- a/src/main/java/com/sas/unravl/auth/BaseUnRAVLAuth.java
+++ b/src/main/java/com/sas/unravl/auth/BaseUnRAVLAuth.java
@@ -20,20 +20,20 @@ import org.springframework.beans.factory.annotation.Autowired;
  * An {@link UnRAVL} script will load UnRAVLAssertion objects while executing
  * the "assert" or "precondition" members of the script. The first field in the
  * assertion member is used as the key, i.e.
- * 
+ *
  * <pre>
  * { "response" : [ ... ] }
  * </pre>
- * 
+ *
  * is an assertion which uses the key "response". The assertion class is found
  * in the {@link UnRAVLPlugins} list of assertions and instantiated. Then, the
- * {@link #check(UnRAVL, JsonNode, Stage, ApiCall)} method is run, passing the
+ * {@link #authenticate(UnRAVL, ObjectNode, ApiCall)} method is run, passing the
  * currently executing {@link UnRAVL} script and the JsonNode element that
  * defines the assertion scriptlet.
  * <p>
  * Extractors should extend {@link BaseUnRAVLAuth} and their check() method
  * should invoke super.check(script,node)
- * 
+ *
  * @author David.Biesack@sas.com
  */
 public class BaseUnRAVLAuth extends BaseUnRAVLPlugin implements UnRAVLAuth {
@@ -57,7 +57,7 @@ public class BaseUnRAVLAuth extends BaseUnRAVLPlugin implements UnRAVLAuth {
 
     /**
      * Create a Null Object assertion
-     * 
+     *
      * @param script
      *            the script
      * @param auth
@@ -83,7 +83,7 @@ public class BaseUnRAVLAuth extends BaseUnRAVLPlugin implements UnRAVLAuth {
     /**
      * Used to register the assertion class with the UnRAVL runtime. This is
      * called from Spring when the UnRAVLPlugins class is loaded.
-     * 
+     *
      * @param plugins
      *            a plugins instance
      */

--- a/src/main/java/com/sas/unravl/auth/BasicAuth.java
+++ b/src/main/java/com/sas/unravl/auth/BasicAuth.java
@@ -31,17 +31,17 @@ import org.apache.http.message.BasicHeader;
  * "auth" : { "basic" : true, "mock" : "false" }
  * </pre>
  * <p>
- * This adds an <code>Authentication:Basic </em>encoded-credentials</em></code>
- * header to the request. The <code></em>encoded-credentials</em></code> is the
+ * This adds an <code>Authentication:Basic <em>encoded-credentials</em></code>
+ * header to the request. The <code><em>encoded-credentials</em></code> is the
  * Base64 encoding of the username:password. The encoded credentials are masked
  * when logging the request headers.
- * 
+ * </p>
  * <p>
  * If mock is true, present mock authentication credentials
  * <p>
  * TODO: allow an alternate location so credentials can be shared across
  * hosts/domains instead of having to have a .netrc file for each host
- * 
+ * </p>
  * <pre>
  * "auth" : { "basic" : "hostname" }
  * </pre>

--- a/src/main/java/com/sas/unravl/auth/CentralAuthenticationServiceAuth.java
+++ b/src/main/java/com/sas/unravl/auth/CentralAuthenticationServiceAuth.java
@@ -41,26 +41,26 @@ import org.apache.log4j.Logger;
  * credentials may be enclosed directly in the "cas" element.
  * <p>
  * This auth element is specified via
- * 
+ *
  * <pre>
  * "auth" : { "cas" : <em>logon-URL</em> }
  * "auth" : { "cas" : <em>logon-URL</em>, "login" : "myuserid" }
  * "auth" : { "cas" : <em>logon-URL</em>, "login" : "userid", "password" : "mySecret" }
  * "auth" : { "cas" : <em>logon-URL</em>, "mock" : <em>boolean-value</em>
  * </pre>
- * 
+ *
  * where <em>logon-URL</em> is a string containing the URL of the ticket
  * granting ticket authentication API, such as
  * <code>"http://www.example.com/SASLogon/v1/tickets"</code>
  * <p>
- * The service ticket is appended as a query parameter to the end of the uri as
- * <code>&ticket=&lt<em>service-ticket</em>></code> or
- * <code>?ticket=&lt<em>service-ticket</em>></code> as needed. The TGT location
- * is added to the environment as <code>&lt<em>hostname</em>>.TGT</code> where
+ * The service ticket is appended as a query parameter to the end of the URI as
+ * <code>&amp;ticket=&lt;<em>service-ticket</em>&gt;</code> or
+ * <code>?ticket=&lt;<em>service-ticket</em>&gt;</code> as needed. The TGT location
+ * is added to the environment as <code>&lt;<em>hostname</em>&gt;.TGT</code> where
  * hostname is taken from the logon-URL value in the JSON specification
  * <p>
  * If mock is true, this precondition will create a mock service ticket.
- * 
+ *
  * @author DavidBiesack@sas.com
  */
 @UnRAVLAuthPlugin("cas")
@@ -125,7 +125,7 @@ public class CentralAuthenticationServiceAuth extends BaseUnRAVLAuth {
      * acquired TGT is also stored in the environment as "{user}.{host}.TGT",
      * and also to "casauth.TGT", which enables logging out by performing a
      * DELETE on the TGT.
-     * 
+     *
      * @param tgt
      *            the ticket granting ticket
      * @param uri

--- a/src/main/java/com/sas/unravl/auth/UnRAVLAuth.java
+++ b/src/main/java/com/sas/unravl/auth/UnRAVLAuth.java
@@ -8,37 +8,36 @@ import com.sas.unravl.UnRAVLPlugins;
 import com.sas.unravl.assertions.UnRAVLAssertion.Stage;
 
 /**
- * An UnRAVL script assertion. Assertion objects run as preconditions before
- * invoking an API call, or as assertions on the results of the API call,
- * checking the status code, headers, response body, or variables, etc. An
- * {@link UnRAVL} script will load UnRAVLAssertion objects while executing the
- * "preconditions" or "assert" members of the script. The first field in the
+ * An UnRAVL script authentication. Authentication objects run before
+ * invoking an API call and may decorate the call. An
+ * {@link UnRAVL} script will load UnRAVLAuth objects while executing the
+ * "auth" members of the script. The first field in the
  * assertion member is used as the key, i.e.
- * 
+ *
  * <pre>
- * { "headers" : specification }
+ * { "basic" : specification }
  * </pre>
- * 
- * is a headers assertion which uses the key "headers". The assertion class is
- * found in the {@link UnRAVLPlugins} list of assertions, and instantiated.
- * Then, the {@link #check(UnRAVL, ObjectNode, Stage, ApiCall)} method is run,
+ *
+ * is a headers assertion which uses the key "basic". The corresponding class is
+ * found in the {@link UnRAVLPlugins} list of authentications, and instantiated.
+ * Then, the {@link #authenticate(UnRAVL, ObjectNode, ApiCall)} method is run,
  * passing the currently executing {@link UnRAVL} script and the JsonNode
- * element that defines the assertion specification (in this case, the value
- * associated with "headers")
+ * element that defines the auth specification (in this case, the value
+ * associated with "auth")
  * <p>
- * Assertions should extend {@link BaseUnRAVLAuth} and their check() method
+ * Authentication plugins should extend {@link BaseUnRAVLAuth} and their autheenticate() method
  * should invoke super.check(script,node)
- * 
+ *
  * @author David.Biesack@sas.com
  */
 public interface UnRAVLAuth {
 
     /**
-     * execute the authentication within the given script
-     * 
+     * Execute the authentication within the given script
+     *
      * @param script
      *            the currently running script
-     * @param auth
+     * @param assertion
      *            the JSON object node which defines this authentication.
      * @param call
      *            the current API call
@@ -48,16 +47,28 @@ public interface UnRAVLAuth {
     public void authenticate(UnRAVL script, ObjectNode assertion, ApiCall call)
             throws UnRAVLException;
 
-    /** Set the scriptlet that defines this assertion */
+    /**
+     * Set the scriptlet that defines this assertion
+     * @param node the UnRAVL scriptlet node
+     */
     public void setAuth(ObjectNode node);
 
-    /** Get the scriptlet that defines this assertion */
+    /**
+     * Get the scriptlet that defines this assertion
+     * @return the scriptlet node
+     */
     public ObjectNode getAuth();
 
-    /** Set the UnRAVL script that this instance is running in */
+    /**
+     * Set the UnRAVL script that this instance is running in
+     * @param script the current UnRAVL script
+     */
     public void setScript(UnRAVL script);
 
-    /** Set the UnRAVL script that this instance is running in */
+    /**
+     * Get the UnRAVL script in which this plugin runs.
+     * @return the current script this plugin is processing
+     */
     public UnRAVL getScript();
 
 }

--- a/src/main/java/com/sas/unravl/extractors/BaseUnRAVLExtractor.java
+++ b/src/main/java/com/sas/unravl/extractors/BaseUnRAVLExtractor.java
@@ -20,20 +20,20 @@ import org.springframework.beans.factory.annotation.Autowired;
  * or elsewhere. An {@link UnRAVL} script will load UnRAVLExtractor objects
  * while executing the "bind" member of the script. The first field in the
  * assertion member is used as the key, i.e.
- * 
+ *
  * <pre>
  * { "headers" : [ ... ] }
  * </pre>
- * 
+ *
  * is a extractor which uses the key "headers". The extractor class is found in
  * the {@link UnRAVLPlugins} list of extractors and instantiated. Then, the
- * {@link #extract(UnRAVL, JsonNode, ApiCall)} method is run, passing the
+ * {@link #extract(UnRAVL, ObjectNode, ApiCall)} method is run, passing the
  * currently executing {@link UnRAVL} script and the JsonNode element that
  * defines the extractor.
  * <p>
  * Extractors should extend {@link BaseUnRAVLExtractor} and their extract()
  * method should invoke super.extract(script,node)
- * 
+ *
  * @author David.Biesack@sas.com
  */
 public class BaseUnRAVLExtractor extends BaseUnRAVLPlugin implements
@@ -60,7 +60,7 @@ public class BaseUnRAVLExtractor extends BaseUnRAVLPlugin implements
     /**
      * Used to register the extractor class with the UnRAVLRuntime This is
      * called from Spring when the UnRAVLPlugins class is loaded.
-     * 
+     *
      * @param plugins
      *            a plugins instance
      */

--- a/src/main/java/com/sas/unravl/extractors/GroovyExtractor.java
+++ b/src/main/java/com/sas/unravl/extractors/GroovyExtractor.java
@@ -21,26 +21,26 @@ import org.apache.log4j.Logger;
  * variable. The scripts can use all defined variable bindings.
  * <p>
  * Usage:
- * 
+ *
  * <pre>
  * "bind" : [
  *    { "groovy" : { var-value-pairs } }
  *    ]
  * </pre>
- * 
+ * <p>
  * The <var>var-value-pairs</var> are JSON object notation such as
  * <code>"varName" : "<em>groovy-expression</em>"</code>. Each
  * <code><em>groovy-expression</em></code> may be a string, a string in the form
  * "@file-or-URL", or an array of such source specifications, as defined in
  * {@link Text}.
- * <p>
+ * </p>
  * <p>
  * Expressions may use any variable binding that is currently in effect,
  * including preceding <var>var-value-pairs</var> in the current "groovy"
  * scriptlet. Example:
- * 
+ * </p>
  * <pre>
- * "bind" : [ 
+ * "bind" : [
  *    { "groovy" : { "pi" : "Math.PI",
  * 	                 "r" : "json.a[2].getDoubleValue()",
  * 	                 "pirsquared" : "pi*r*r",
@@ -49,12 +49,13 @@ import org.apache.log4j.Logger;
  * 	  }
  * 	  ],
  * </pre>
- * 
+ *
  * <p>
  * The final Groovy script value is subject to environment expansion before
  * running. All variables in the environment are available as local variables
  * when the Groovy script runs.
- * 
+ * </p>
+ *
  * @author David.Biesack@sas.com
  */
 @UnRAVLExtractorPlugin({ "groovy", "Groovy" })
@@ -99,7 +100,7 @@ public class GroovyExtractor extends BaseUnRAVLExtractor {
     /**
      * Evaluate script as a Groovy expression and return the result. Environment
      * variable expansion is performed on the input before evaluation.
-     * 
+     *
      * @param call
      *            the API call context
      * @param source

--- a/src/main/java/com/sas/unravl/extractors/HeadersExtractor.java
+++ b/src/main/java/com/sas/unravl/extractors/HeadersExtractor.java
@@ -23,20 +23,20 @@ import org.apache.log4j.Logger;
  * optionally parse them into constituent fields.
  * <p>
  * The format is:
- * 
+ *
  * <pre>
  * { "headers" : json-object }
  * </pre>
- * 
+ *
  * For example,
- * 
+ *
  * <pre>
- * { "headers" : { "contentType" : "Content-Type", 
- *                 "location" : "Location" 
+ * { "headers" : { "contentType" : "Content-Type",
+ *                 "location" : "Location"
  *               }
  * }
  * </pre>
- * 
+ *
  * This will bind the value of the Content-Type header to the variable
  * "contentType" and the value of the Location header to the variable
  * "location". If the right hand side of a pair is an array instead of a string,
@@ -45,32 +45,32 @@ import org.apache.log4j.Logger;
  * bound to the groups that are matched from the pattern. The value of the
  * header is parsed with a regular expression and the groups bound to variables.
  * For example,
- * 
+ *
  * <pre>
  * { "headers" : {
  *     "contentType" : [ "Content-Type", "^(.*)\\s*;\\s*charset=(.*)$", "mediaType", "charset" ]
  *     }
  * }
  * </pre>
- * 
+ *
  * will bind contentTye to the complete value of the Content-Type header, and
  * extract the media type and charset into variables named "mediaType" and
  * "charset" according to the pattern.
- * 
- * (Note that a per the JSON grammar, \ characters in a JSON string must be
- * escaped, so the regular expression notation <code>\s</code> is coded in the
- * JSON string as <code>\\s</code>.)
- * 
+ * <p>
+ * (Note that a per the JSON grammar, \\ characters in a JSON string must be
+ * escaped, so the regular expression notation <code>\\s</code> is coded in the
+ * JSON string as <code>\\\\s</code>.)
+ *
  * </p>
  * For example, if the Content-Type header was
- * 
+ *
  * <pre>
  * application/json;charset=UTF-8
  * </pre>
- * 
- * this headers specification will bind the variables:<br/>
- * responseType to "application/json; charset=UTF-8"<br/>
- * mediaType to "application/json, and <br/>
+ *
+ * this headers specification will bind the variables:<br>
+ * responseType to "application/json; charset=UTF-8"<br>
+ * mediaType to "application/json, and <br>
  * charset to "UTF-8".
  * <p>
  * If the regular expression does not match, this extractor will throw an
@@ -81,45 +81,45 @@ import org.apache.log4j.Logger;
  * false positive.
  * <p>
  * The (deprecated) format is
- * 
+ *
  * <pre>
  * { "headers" : array-of-matchers  }
  * </pre>
- * 
+ *
  * where each element of the array is a subarray of strings, in the form
- * 
+ *
  * <pre>
  * [ header, var ]
  * </pre>
- * 
+ *
  * such as
- * 
+ *
  * <pre>
  * [ "Content-Type", "responseType" ]
  * </pre>
- * 
+ *
  * which will bind the value of the Content-Type header into the environment
  * variable named "responseType".
  * <p>
  * The more advanced form works like the {@link PatternExtractor} and binds
  * regular expression grouping values into additional environment variable
  * bindings. in the form
- * 
+ *
  * <pre>
  * [ header, var ]
  * </pre>
- * 
+ *
  * such as
- * 
+ *
  * <pre>
  * [ "Content-Type", "responseType", "^(.*)\\s*;\\s*charset=(.*)$", "mediaType", "charset" ]
  * </pre>
- * 
+ *
  * which will bind the value of the Content-Type header into the environment
  * variable named "responseType", then perform pattern matching to extract the
  * media type and the encoding character set into the variables mediaType and
  * charset.
- * 
+ *
  * @author David.Biesack@sas.com
  */
 

--- a/src/main/java/com/sas/unravl/extractors/LinksExtractor.java
+++ b/src/main/java/com/sas/unravl/extractors/LinksExtractor.java
@@ -26,7 +26,7 @@ import org.apache.log4j.Logger;
  * representations. This is also compatible with <a
  * href='http://amundsen.com/media-types/collection/'>Collection+JSON</a>
  * format.
- * 
+ *
  * <pre>
  *  {  ...,
  *     "links" : [
@@ -44,7 +44,7 @@ import org.apache.log4j.Logger;
  *     ...
  *  }
  * </pre>
- * 
+ *
  * We will refer to the above as the atom:link response. With Collection+JSON,
  * the "links" are embedded in the top level "collection" object.
  * <p>
@@ -53,7 +53,7 @@ import org.apache.log4j.Logger;
  * The second format is the the <a
  * href='http://stateless.co/hal_specification.html'>Hypertext Application
  * Language</a> (HAL) representation by Mike Kelly which uses a "_links" member:
- * 
+ *
  * <pre>
  *  { ...,
  *    "_links": {
@@ -62,7 +62,7 @@ import org.apache.log4j.Logger;
  *    }
  *  }
  * </pre>
- * 
+ *
  * We will refer to this as the HAL response.
  * <p>
  * This UnRAVL "bind" element can extract links from only one set of links in a
@@ -72,14 +72,14 @@ import org.apache.log4j.Logger;
  * want to extract links from another environment variable or expression.
  * <p>
  * The syntax for the links extractor is
- * 
+ *
  * <pre>
  *  { "links" : { "var1" : selector1,
  *                "var2" : selector2,
  *                ...
  *                "varn" : selectorn } }
  * </pre>
- * 
+ *
  * "var1" through "varn" are environment variable names which will be bound to
  * the links as per their corresponding selectors. Each selector may be:
  * <dl>
@@ -96,29 +96,29 @@ import org.apache.log4j.Logger;
  * Instead of an object of name/spec pairs, the value of the links extractor may
  * be an array of strings, in which case each string is used as both the
  * variable name and the link relation (selector) name. Thus,
- * 
+ *
  * <pre>
  *  { "links" : [ "self", "update", "delete" ] }
  * </pre>
- * 
+ *
  * is equivalent to
- * 
+ *
  * <pre>
  *  { "links" : { "self" : "self", "update" : "update", "delete" : "delete" ] }
  * </pre>
- * 
+ *
  * Finally, a single value may be used:
- * 
+ *
  * <pre>
  *  { "link" : "self" }
  * </pre>
- * 
+ *
  * which is equivalent to
- * 
+ *
  * <pre>
  *  { "link" : { "self" : "self" } }
  * </pre>
- * 
+ *
  * Note that "link" may be used instead of "links"; this is clearer for
  * extracting a single link.
  * <h3>Extracting just the href value from links</h3>
@@ -127,40 +127,40 @@ import org.apache.log4j.Logger;
  * then the extracted value will be just the string value of the "href" member
  * of the corresponding link representation. not the entire link object. For
  * example,
- * 
+ * </p>
  * <pre>
  *  { "links" : [ "self", "update", "delete" ] }
  * </pre>
- * 
+ * <p>
  * will bind "self", "update", and "delete" to the corresponding <strong>href
  * string values</strong> of the "self", "update, and "delete" links links.
  * </p>
  * <h2>Extracting from JSON other than responseBody</h2>
  * <p>
  * The links/href extractors also has an additional option
- * 
+ *
  * <pre>
  *              "from" : "var-or-path"
  * </pre>
  * <p>
  * If "from" is present, its value should be the name of an UnRAVL variable that
  * contains the links collection. By default, this is the JSON response object.
- * 
+ *
  * <h2>Example: Extracting multiple links</h2>
- * 
+ *
  * <p>
  * Consider two different JSON responses, the atom:link response and the HAL
  * response, as described above. The UnRAVL "bind" element
- * 
+ *
  * <pre>
  *  { "links" : { "selfLink" : "self",
  *                "searchLink" : "search" }
  *  }
  * </pre>
- * 
+ *
  * will select links based on their "rel" names. This will bind the variable
  * "selfLink" to the object
- * 
+ *
  * <pre>
  *  { "rel" : "self",
  *    "method" : "GET",
@@ -168,57 +168,56 @@ import org.apache.log4j.Logger;
  *    "type" : "application/json"
  *  }
  * </pre>
- * 
+ *
  * when used with the the atom:link response, or to the object
- * 
+ *
  * <pre>
  *  { "href": "/orders" }
  * </pre>
- * 
+ * <p>
  * when used with the HAL response. The variable named "searchLink" will be
  * bound to the link with the link relation "search".
- * <p>
- * 
+ * </p>
+ *
  * <pre>
  *  { "href" : [ "self", "search" ] }
  * </pre>
- * 
+ *
  * will bind "self" to the string "http://www.example.com/orders" and bind
  * "search" to the string "http://www.example.com/orders?id={order_id}" (because
  * we use the "href" form instead of the "links" form.)
- * 
+ *
  * <h2>Example: Extracting from other sources</h2>
- * 
+ *
  * By default, this extractor works on the variable named "responseBody" which
  * is bound when using the "json" extractor. However, you can use the optional
  * "from" member to name another variable that is bound, or you can use a Groovy
  * expression that returns a JsonNode. This is useful if you want to extract the
  * links of nested objects. It is required for Collection+JSON nodes to select
  * from the "collection" element inside the response, for example.
- * <p>
- * 
+ *
  * <pre>
  *  "bind" : [
  *             { "href" : { "coll" : "self" },
  *               "from" : "responseBody.collection" } },
- * 
+ *
  *             { "href" : { "self0" : "self",
  *                          "delete0" : "delete" },
  *               "from" : "responseBody.collection.items[0]" } },
- * 
+ *
  *             { "href" : { "selfLast" : "self",
  *                          "deleteLast" : "delete" },
  *               "from" : "responseBody.collection.items[responseBody.collection.items.size()-1]" } }
  *           ]
  * </pre>
- * 
+ *
  * this will extract the href from the link to the collection as well as the the
  * href values from the "self" and "delete" links in the first and last element
  * of the nested items array, respectively. Environment variable substitution is
  * performed on the string before evaluating it as a Groovy expression.
- * 
+ *
  * <h2>Example: Complex matching</h2>
- * 
+ *
  * By default, if the selector is a string, this extractor only matches the link
  * relation. This is also the only option for HAL. For atom:link, the "links"
  * array may contain multiple links with the same link relation. Thus, you may
@@ -226,7 +225,7 @@ import org.apache.log4j.Logger;
  * or more members of the link. For example, to match a link that has a "rel"
  * value of "update" and a "method" value of "PUT" and a "href" label that
  * contains "models", use
- * 
+ *
  * <pre>
  *  "bind" : { "link" : { "updateLink" : { "rel" : "update",
  *                                         "method" : "PUT",
@@ -237,13 +236,13 @@ import org.apache.log4j.Logger;
  * </pre>
  * <p>
  * It is easy to see that
- * 
+ *
  * <pre>
  *  "bind" : { "link" : { "updateLink" : "update" } }
  * </pre>
- * 
+ *
  * is shorthand for
- * 
+ *
  * <pre>
  *  "bind" : { "link" : { "updateLink" : { "rel" : "update" } } }
  * </pre>
@@ -251,7 +250,7 @@ import org.apache.log4j.Logger;
  * (Note that this element may be specified with either "links" or "link",
  * depending on your preference - use "links" when binding more than one link,
  * and "link" when binding only one.)
- * 
+ *
  * @author David.Biesack@sas.com
  */
 

--- a/src/main/java/com/sas/unravl/extractors/PatternExtractor.java
+++ b/src/main/java/com/sas/unravl/extractors/PatternExtractor.java
@@ -19,42 +19,44 @@ import org.apache.log4j.Logger;
  * Matches text against grouping regular expressions and binds the substrings
  * into constituent variable bindings in the current UnRAVL script environment.
  * The extractor form is
- * 
+ *
  * <pre>
  * { "pattern" : [ string, pattern, var0, ... varn ] }
  * </pre>
- * 
+ *
  * such as
- * 
+ *
  * <pre>
  * { "pattern" : [ "{responseType}", "^(.*)\\s*;\\s*charset=(.*)$", "mediaType", "charset" ] }
  * </pre>
- * 
+ *
  * This will match the value of the environment expansion of "{responseType}" to
- * the given regular expression pattern <code>^(.*)\s*;\s*charset=(.*)$</code>,
+ * the given regular expression pattern <code>^(.*)\\s*;\\s*charset=(.*)$</code>,
  * and bind the media type and the encoding character set substrings to the
  * variables <code>mediaType</code> and <code>charset</code>. (Note that a per
- * the JSON grammar, backslash (<code>\</code>) characters in a JSON string must
- * be escaped, so the regular expression notation <code>\s</code> is coded in
- * the JSON string as <code>\\s</code>.) </p> For example, if the
+ * the JSON grammar, backslash (<code>\\</code>) characters in a JSON string must
+ * be escaped, so the regular expression notation <code>\\s</code> is coded in
+ * the JSON string as <code>\\\\s</code>.)
+ * <p>
+ * For example, if the
  * <code>responseType</code> binding in the environment was
- * 
+ *
  * <pre>
  * application/json; charset=UTF-8
  * </pre>
- * 
- * this pattern specification will bind the variables:<br/>
- * mediaType to <code>"application/json"</code>, and <br/>
+ *
+ * this pattern specification will bind the variables:<br>
+ * mediaType to <code>"application/json"</code>, and <br>
  * charset to <code>"UTF-8"</code>.
  * <p>
  * If the regular expression does not match, this extractor will throw an
  * {@link UnRAVLAssertionException}
- * 
+ *
  * <p>
  * This extractor will unbind all the variables before testing the regular
  * expression, so that bindings left from other tests won't persist and leave a
  * false positive.
- * 
+ *
  * @author David.Biesack@sas.com
  *
  */

--- a/src/main/java/com/sas/unravl/extractors/TextExtractor.java
+++ b/src/main/java/com/sas/unravl/extractors/TextExtractor.java
@@ -19,13 +19,13 @@ import org.apache.log4j.Logger;
 
 /**
  * An extractor for
- * 
+ *
  * <pre>
  * { "text" : "varName" }
  * { "text" : "@file-name" }
  * </pre>
  *
- * @todo: allow an encoding, such as<br/>
+ * TODO: allow an encoding, such as<br>
  *        <code>{ "text" : "@file-name", "encoding": "UTF-16" }</code>
  * @author David.Biesack@sas.com
  */

--- a/src/main/java/com/sas/unravl/generators/BaseUnRAVLRequestBodyGenerator.java
+++ b/src/main/java/com/sas/unravl/generators/BaseUnRAVLRequestBodyGenerator.java
@@ -28,7 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * 
  * is a body generator which uses the key "json". The body generator class is
  * found in the {@link UnRAVLPlugins} list of body generator classes and
- * instantiated. Then, the {@link #getBody(UnRAVL, JsonNode, ApiCall)} method is
+ * instantiated. Then, the {@link #getBody(UnRAVL, ObjectNode, ApiCall)} method is
  * run, passing the currently executing {@link UnRAVL} script and the JsonNode
  * scriptlet element that defines the body generator.
  * <p>
@@ -53,8 +53,8 @@ public class BaseUnRAVLRequestBodyGenerator extends BaseUnRAVLPlugin implements
      * Used to register the body generator class with the UnRAVL runtime This is
      * called from Spring when the UnRAVLPlugins class is loaded.
      * 
-     * @param runtime
-     *            a runtime instance
+     * @param plugins
+     *            UnRVAL plugins manager instance
      */
     @Autowired
     public void setPluginManager(UnRAVLPlugins plugins) {

--- a/src/main/java/com/sas/unravl/generators/Binary.java
+++ b/src/main/java/com/sas/unravl/generators/Binary.java
@@ -44,10 +44,10 @@ public class Binary {
      * ObjectNode <code>{ "binary" : [ 0, 2, 1, 3 ]}</code> the constructor new
      * Binary(object, "binary")
      * 
-     * @param node
-     * @param fieldName
-     * @throws IOException
-     * @throws UnRAVLException
+     * @param node the JSON node for this scriptlet
+     * @param fieldName the field name (normally "binary")
+     * @throws IOException if an I/O exception occurs
+     * @throws UnRAVLException if an other exception occurs, including invalid JSON specification.
      */
     public Binary(ObjectNode node, String fieldName) throws IOException,
             UnRAVLException {
@@ -61,8 +61,8 @@ public class Binary {
      *            either a TextNode with the value "@file-or-url", or a
      *            ArrayNode that contains integer byte values (0 to 255) or
      *            "@file-or-url" strings, or nested arrays.
-     * @throws IOException
-     * @throws UnRAVLException
+     * @throws IOException an I/O error occurred 
+     * @throws UnRAVLException Some other exception occurred, including invalid JSON specification
      */
     public Binary(JsonNode binarySpec) throws IOException, UnRAVLException {
         build(binarySpec);
@@ -124,10 +124,10 @@ public class Binary {
      * Copy bytes from an input stream to an output stream.
      * 
      * @param in
-     *            the input stream. This is closed when done
+     *            the input stream. This is closed when done.
      * @param out
-     *            the output stream. This is <bold>not</bold> closed.
-     * @throws IOException
+     *            the output stream. This is <strong>not</strong> closed.
+     * @throws IOException if there is an error reading from in or writing to out
      */
     public static void copy(InputStream in, OutputStream out)
             throws IOException {

--- a/src/main/java/com/sas/unravl/generators/BinaryRequestBodyGenerator.java
+++ b/src/main/java/com/sas/unravl/generators/BinaryRequestBodyGenerator.java
@@ -13,21 +13,20 @@ import java.io.InputStream;
 /**
  * Generates a binary request body for this API call. The node bodySpec can have
  * one of several forms:
- * 
+ *
  * <pre>
  * { "body" : [ array of byte values }
  * { "body" : "@file-or-URL" }
  * { "body" : [ array-of-binary-or-@file-or-URL ]
  * </pre>
- * 
+ *
  * which are used to create a byte array which will be passed as the REST API
- * call's request body. The body is build as described in {@Binary}.
- * <p>
- * 
+ * call's request body. The body is build as described in {@link Binary}.
+ *
  * <p>
  * The resulting <code>byte[]</code> is bound to the current environment as
  * <code>"requestBody"</code>.
- * 
+ *
  * @author David.Biesack@sas.com
  *
  */

--- a/src/main/java/com/sas/unravl/generators/Text.java
+++ b/src/main/java/com/sas/unravl/generators/Text.java
@@ -28,17 +28,19 @@ import java.nio.charset.Charset;
  * { "key" : array-of-text }
  * </pre>
  * 
- * </p>
  * <p>
  * In the first form, the text is expressed as a single JSON string.
  * </p>
+ * <p>
  * In the second form, the text is read from a text file or a URL. The text is
- * assumed to be in UTF-8 encoding. </p>
+ * assumed to be in UTF-8 encoding. 
+ * </p>
  * <p>
  * In the third form, Text will combine texts in an array. Each element of the
  * array may be a text-value or a <code>{@literal @}file-or-url</code> or a
  * nested array. The values are separated by a newline. If you want a trailing
  * newline, the last value should be the empty string, "".
+ * </p>
  * <p>
  * TODO: add an <code>"encoding" : <em>encoding-name</em></code>
  * </p>

--- a/src/main/java/com/sas/unravl/generators/TextRequestBodyGenerator.java
+++ b/src/main/java/com/sas/unravl/generators/TextRequestBodyGenerator.java
@@ -14,18 +14,18 @@ import java.io.InputStream;
 /**
  * Generates a text request body for this API call. The value associated with
  * "body" can have one of several forms:
- * 
+ *
  * <pre>
  * { "text" : "request body string" }
  * { "text" : "@file-or-URL" }
  * { "text" : [ array-of-text-or-@file-or-URL ]
  * </pre>
- * 
- * The request body is built as described in {@Text}.
+ *
+ * The request body is built as described in {@link Text}.
  * <p>
  * The text is bound to the current environment as a string named
  * <code>"requestBody"</code>.
- * 
+ *
  * @author David.Biesack@sas.com
  *
  */

--- a/src/main/java/com/sas/unravl/generators/UnRAVLRequestBodyGenerator.java
+++ b/src/main/java/com/sas/unravl/generators/UnRAVLRequestBodyGenerator.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 public interface UnRAVLRequestBodyGenerator {
     /**
      * Generate the body. This is done by providing an input stream (Perhaps
-     * this should just be a Future<byte []>). The UnRAVL script will call this
+     * this should just be a Future&lt;byte []&gt;). The UnRAVL script will call this
      * and read the stream and store the result.
      * 
      * @param script
@@ -30,8 +30,8 @@ public interface UnRAVLRequestBodyGenerator {
      * @param call
      *            The current API call
      * @return an input stream which the script will read
-     * @throws IOException
-     * @throws UnRAVLException
+     * @throws IOException if an I/O problem occurs
+     * @throws UnRAVLException if the body cannot be generated
      */
     public InputStream getBody(UnRAVL script, ObjectNode scriptlet, ApiCall call)
             throws IOException, UnRAVLException;

--- a/src/main/java/com/sas/unravl/util/Json.java
+++ b/src/main/java/com/sas/unravl/util/Json.java
@@ -30,7 +30,7 @@ import org.apache.log4j.Logger;
 
 /**
  * JSON utility methods.
- * 
+ *
  * @author David.Biesack@sas.com
  */
 public class Json {
@@ -39,11 +39,11 @@ public class Json {
 
     /**
      * Convenience method for parsing a string as JSON.
-     * 
+     *
      * @param json
      *            text JSON; this must be valid
      * @return the root JsonNode
-     * @throws IllegalArgumentException
+     * @throws UnRAVLException
      *             if the json is not valid.
      */
     public static JsonNode parse(String json) throws UnRAVLException {
@@ -61,13 +61,12 @@ public class Json {
     /**
      * Process a JsonNode and its subtree and perform environment expansion on
      * all text.
-     * 
+     *
      * @param actual
      *            an input Json
      * @param script
      *            the Unravl script
      * @return a new JsonNode with the text mapped
-     * @throws UnRAVLException
      */
     public static JsonNode expand(JsonNode actual, final UnRAVL script) {
         final JsonNodeFactory jnf = jsonNodeFactory();
@@ -77,7 +76,7 @@ public class Json {
          * each string with its environment expansion, That is, replace
          * {varName} with the current binding for "varName" in the script's
          * environment.
-         * 
+         *
          * @param node
          *            the input JSON
          * @return the node or a replacement which the text expanded.
@@ -98,7 +97,7 @@ public class Json {
                     ObjectNode from = (ObjectNode) node;
                     ObjectNode to = new ObjectNode(jnf);
                     for (Map.Entry<String, JsonNode> f : Json.fields(from)) {
-                        to.put(f.getKey(), this.apply(f.getValue()));
+                        to.set(f.getKey(), this.apply(f.getValue()));
                     }
                     return to;
                 } else
@@ -112,21 +111,21 @@ public class Json {
     /**
      * Transform a JsonNode tree by applying a mapping function to the nodes in
      * it.
-     * 
-     * @param actual
-     * @param mappingFunction
+     *
+     * @param node the input JSON
+     * @param mappingFunction a Function that maps a node to a node
      * @return the transformed map which may be the input JsonNode or a new
      *         node.
      */
-    public static JsonNode map(JsonNode actual,
+    public static JsonNode map(JsonNode node,
             Function<JsonNode, JsonNode> mappingFunction) {
-        return mappingFunction.apply(actual);
+        return mappingFunction.apply(node);
     }
 
     /**
      * Return the input node as an ArrayNode when an UnRAVL script expects an
      * array node.
-     * 
+     *
      * @param node
      *            input node
      * @return the input node, cast as an ArrayNode
@@ -146,7 +145,7 @@ public class Json {
     /**
      * Return the input node as an ObjectNode when an UnRAVL script expects an
      * array node.
-     * 
+     *
      * @param node
      *            input node
      * @return the input node, cast as an ObjectNode
@@ -166,7 +165,7 @@ public class Json {
     /**
      * Return the input node as an TextNode when an UnRAVL script expects an
      * text node.
-     * 
+     *
      * @param node
      *            input node
      * @return the input node, cast as an TextNode
@@ -186,7 +185,7 @@ public class Json {
 
     /**
      * Access the first field of a JsonNode, which must be an ObjectNode
-     * 
+     *
      * @param node
      *            a JsonNode which will be used as an ObjectNode
      * @return the first field in the ObjectNode as a Map.Entry
@@ -207,7 +206,7 @@ public class Json {
 
     /**
      * Convert an ArrayNode into an iterable list of JsonNode
-     * 
+     *
      * @param node
      *            a JsonNode which will be used as an ObjectNode
      * @return a List containing the elements
@@ -226,7 +225,7 @@ public class Json {
 
     /**
      * Return the name of the first field in a JsonNode
-     * 
+     *
      * @param node
      *            a node which must be a non-empty ObjectNode
      * @return the name of the first field
@@ -239,7 +238,7 @@ public class Json {
 
     /**
      * Return the name of the first field in a JsonNode
-     * 
+     *
      * @param node
      *            a node which must be a non-empty ObjectNode
      * @return the value of the first field
@@ -259,7 +258,7 @@ public class Json {
 
     /**
      * Convert an ObjectNode to a List of Map.Entry objects
-     * 
+     *
      * @param object
      *            an JSON object
      * @return a List of Map.Entry objects. These are active and updating them
@@ -277,7 +276,7 @@ public class Json {
 
     /**
      * Write a JSON tree to a stream
-     * 
+     *
      * @param json
      *            the JSON node
      * @param fileName
@@ -325,7 +324,7 @@ public class Json {
     /**
      * If the JSON node contains a field with the given name and it is text,
      * return that text, else return the default value
-     * 
+     *
      * @param node
      *            a JSON node
      * @param fieldName

--- a/src/main/java/com/sas/unravl/util/VariableResolver.java
+++ b/src/main/java/com/sas/unravl/util/VariableResolver.java
@@ -211,6 +211,8 @@ public class VariableResolver {
     }
 
     /** 
+     * Test if a string is a Unicode code point that matches the pattern "U+hhhh".
+     * @param string the input string
      * @return True if string matches "U+hhhh" where hhhh is four hex digits.
      * Case is ignored.
      */

--- a/src/test/scripts/hello.json
+++ b/src/test/scripts/hello.json
@@ -1,0 +1,23 @@
+{ "name" : "POST a hello message to httpbin",
+  "env" : { "data" :  { "greeting" : "Hello, httpbin, from UnRAVL\n" }},
+  "POST" : "http://www.httpbin.org/post",
+  "headers" : { "Content-Type" : "text/plain",
+                "Accept" : "text/plain",
+                "Agent" : "UnRAVL"
+              },
+  "body" : { "json" : "data" },
+  "bind" : [ { "json" : "-" },
+             { "json" : "responseBody" },
+             { "groovy" : {
+                 "actual" : "responseBody.json",
+                 "sentHeaders" : "responseBody.headers"
+                 }
+               }
+             ],
+  "assert" : [
+      "data == actual",
+      "sentHeaders['Accept'].textValue() == 'text/plain'",
+      "sentHeaders['Content-Type'].textValue() == 'text/plain'",
+      "sentHeaders['Agent'].textValue() == 'UnRAVL'"
+      ]
+}


### PR DESCRIPTION
Update third party dependencies to more current versions.
This build.gradle files will set dependencies on the most recent release versions.
Also cleaned up javadoc errors so Gradle can build javadoc cleanly.

