### PR TITLE
Improve .netrc parsing

### DIFF
--- a/doc/Authentication.md
+++ b/doc/Authentication.md
@@ -95,12 +95,23 @@ Credentials must be specified entirely on one line:
 
 `machine` *`hostname`* `login` *`userid`* `password` *`password`*
 
+`machine` *`hostname`* `login` *`userid`* `password` *`password`* `port` *`port`*
+
 such as
 
 ```
  machine rdcesx51019.race.sas.com login testuser password testuserSecret123
+ machine rdcesx51019.race.sas.com user testuser password testuserSecret123 port 8080
 ```
-The *hostname* field must exactly match the hostname in UnRAVL API calls.
+
+You may use either the .netrc standard `login` key, or
+the key `user` to identify the login/user ID.
+
+The port is optional; use this if you want to match
+a test API on a non-default port such as port 8080.
+
+The *hostname* field must *exactly* match the hostname in UnRAVL API
+calls.
 
 You may also embed the credentials directly inside the authentication element in the script.
 These may be the login id and password (if there are no security issues with directly embedding

--- a/src/main/java/com/sas/unravl/auth/AbstractCredentialsProvider.java
+++ b/src/main/java/com/sas/unravl/auth/AbstractCredentialsProvider.java
@@ -5,10 +5,19 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sas.unravl.UnRAVLRuntime;
 import com.sas.unravl.util.Json;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 /**
- * Abstract implementation of the CredentialsProvider interfcae.
+ * Abstract implementation of the CredentialsProvider interface.
+ * Subclasses need only implement
+ * <pre>
+ *  public HostCredentials getHostCredentials(String host, String port,
+ *          String userName, String password, boolean mock)
+ * </pre>
+ * <p>
+ * This class also provides utility methods  {@link #host(String)} and {@link #port(String)} to split host:port
+ * into its parts.
  * @author David.Biesack@sas.com
  */
 abstract public class AbstractCredentialsProvider implements
@@ -31,7 +40,7 @@ abstract public class AbstractCredentialsProvider implements
      * and store them in .netrc in the current directory.)
      * 
      * @param host
-     *            the host name
+     *            the host name or host:port string
      * @param auth
      *            The JsonNode containing the auth contents (usually login and
      *            password)
@@ -41,6 +50,7 @@ abstract public class AbstractCredentialsProvider implements
      * @throws IOException
      *             if we could not read the .netrc file
      */
+    @Override
     public HostCredentials getHostCredentials(String host, ObjectNode auth,
             boolean mock) throws IOException {
         if (mock)
@@ -49,7 +59,32 @@ abstract public class AbstractCredentialsProvider implements
         String password = Json.stringFieldOr(auth, "password", null);
         return getHostCredentials(host, userName, password, mock);
     }
+    /**
+     * @param hostPort A hostname or hostname:port string
+     * @return the host string, minus ant :port suffix
+     */
+    public static String host(String hostPort) {
+        int colon = hostPort.indexOf(':');
+        if (colon > -1)
+            return hostPort.substring(0, colon);
+        return hostPort;
+    }
 
+    /** 
+     * @param hostPort A hostname or hostname:port string
+     * @return the port string if hostPort string matches host:port, else null
+     */
+    public static String port(String hostPort) {
+        int colon = hostPort.indexOf(':');
+        if (colon > -1)
+            return hostPort.substring(colon+1);
+        return null;
+    }
+
+    /**
+     * Mock credentials, for testing
+     * @return "mockuser", "mockpassword"
+     */
     protected HostCredentials mockCredentials() {
         return credentials("mockuser", "mockpassword");
     }
@@ -57,5 +92,6 @@ abstract public class AbstractCredentialsProvider implements
     protected HostCredentials credentials(String login, String password) {
         return new HostCredentials ( runtime.expand(login), runtime.expand(password) );
     }
+
 
 }

--- a/src/main/java/com/sas/unravl/auth/CredentialsPortProvider.java
+++ b/src/main/java/com/sas/unravl/auth/CredentialsPortProvider.java
@@ -9,10 +9,10 @@ import java.io.IOException;
 
 /**
  * An interface for an object that can provide user credentials
- * (login id, password) for connecting to a host.
+ * (login id, password) for connecting to a host/port
  * @author David.Biesack@sas.com
  */
-public interface CredentialsProvider {
+public interface CredentialsPortProvider extends CredentialsProvider {
 
     /**
      * Get credentials for the host. Note: If reading credentials from a .netrc
@@ -21,7 +21,9 @@ public interface CredentialsProvider {
      * and store them in .netrc in the current directory.)
      *
      * @param host
-     *            the host name or host:port string
+     *            the host name
+     * @param port
+     *            the port for the host; this may be null (which implies the default port, 80)
      * @param auth
      *            The JsonNode containing the auth contents (usually login and
      *            password)
@@ -31,17 +33,19 @@ public interface CredentialsProvider {
      * @throws IOException
      *             if we could not read the .netrc file
      */
-    public HostCredentials getHostCredentials(String host, ObjectNode auth,
+    public HostCredentials getHostCredentials(String host, String port, ObjectNode auth,
             boolean mock) throws IOException;
 
     /**
-     * Get credentials for the host, user, and password. Note: If reading credentials from a .netrc
+     * Get credentials for the host, user, and passwprd. Note: If reading credentials from a .netrc
      * file, the credentials are <em>not</em> cached; we reread the .netrc file
      * each time. (This allows one script to obtain credentials from a service
      * and store them in .netrc in the current directory.)
      *
      * @param host
-     *            the host name or host:port string
+     *            the host name
+     * @param port
+     *            the port for the host; this may be null (which implies the default port, 80)
      * @param userName the user's login name/id
      * @param password the user's password/secret
      * @param mock
@@ -52,9 +56,8 @@ public interface CredentialsProvider {
      * @throws IOException
      *             if we could not read the .netrc or _netrc file
      */
-    public abstract HostCredentials getHostCredentials(String host, String userName,
+    public abstract HostCredentials getHostCredentials(String host, String port, String userName,
             String password, boolean mock) throws FileNotFoundException,
             IOException;
 
-    public void setRuntime(UnRAVLRuntime runtime);
 }

--- a/src/main/java/com/sas/unravl/auth/NetrcCredentialsProvider.java
+++ b/src/main/java/com/sas/unravl/auth/NetrcCredentialsProvider.java
@@ -24,12 +24,13 @@ import java.util.regex.Pattern;
  * That file is read from the current directory, or if not found there, from the
  * home directory (<code>.~/.netrc</code> or <code>.%USERPROFILE%\\.netrc</code>
  * ). The file contains lines in the following format:
- *
+ * </p>
  * <pre>
  * machine <em>qualified.hostname</em> login <em>userid-for-host</em> password <em>password-for-host</em>
- * 
+ *
  * machine <em>qualified.hostname</em> login <em>userid-for-host</em> password <em>password-for-host</em> port <em>port-number</em>
  * </pre>
+ * <p>
  * Items must appeaqr in this order.
  * You may use <code>user</code> instead of <code>login</code>.
  * </p>
@@ -56,7 +57,7 @@ public class NetrcCredentialsProvider extends AbstractCredentialsProvider {
      static final int QUOTED_PASSWORD_GROUP = 5;
      static final int UNQUOTED_PASSWORD_GROUP = 6;
      static final int PORT_GROUP = 8;
-             
+
     /* (non-Javadoc)
      * @see com.sas.unravl.auth.CredentialsProvider#getCredentials(java.lang.String, java.lang.String, java.lang.String, boolean)
      */
@@ -72,7 +73,7 @@ public class NetrcCredentialsProvider extends AbstractCredentialsProvider {
                 return credentials(login, password);
         }
 
-        // Locate the netrc config file that contains credentials for hosts 
+        // Locate the netrc config file that contains credentials for hosts
         File netrc = new File(".netrc"); // look in current dir first
         if (!netrc.exists())
             netrc = new File("_netrc"); // possible Windows file name, in current dir

--- a/src/main/java/com/sas/unravl/auth/NetrcCredentialsProvider.java
+++ b/src/main/java/com/sas/unravl/auth/NetrcCredentialsProvider.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -16,6 +17,7 @@ import java.util.regex.Pattern;
  * properties <code>"login"</code> and <code>"password"</code>. Environment
  * substitution is applied to these strings, so you can set the credentials in
  * unRAVL variables or pass them as system properties.
+ * </p>
  * <p>
  * If the authentication element does not contain credentials, search for them
  * by host in <code>.netrc</code> file (or <code>._netrc</code> on Windows).
@@ -25,11 +27,18 @@ import java.util.regex.Pattern;
  *
  * <pre>
  * machine <em>qualified.hostname</em> login <em>userid-for-host</em> password <em>password-for-host</em>
+ * 
+ * machine <em>qualified.hostname</em> login <em>userid-for-host</em> password <em>password-for-host</em> port <em>port-number</em>
  * </pre>
- *
+ * Items must appeaqr in this order.
+ * You may use <code>user</code> instead of <code>login</code>.
+ * </p>
+ * <p>
+ * Passwords with whitespace in them must be quoted with double quotes. passwords may
+ * not contain double quote characters.
  * @author DavidBiesack@sas.com
  */
-public class NetrcCredentialsProvider extends AbstractCredentialsProvider implements CredentialsProvider {
+public class NetrcCredentialsProvider extends AbstractCredentialsProvider {
 
     /**
      * Create a Credentials instance for use with the UnRAVL runtime
@@ -37,15 +46,23 @@ public class NetrcCredentialsProvider extends AbstractCredentialsProvider implem
     public NetrcCredentialsProvider() {
     }
 
+    // This regex pattern matches the .netrc file format, described in the javadoc comment above
+    // examples are in src/test/data/.netrc
     static final Pattern NETRC = Pattern
-            .compile("^\\s*machine\\s+([^\\s]+)\\s+login\\s+([^\\s]+)\\s+password\\s+([^\\s]+).*$");
-
+            .compile("^\\s*machine\\s+([^\\s]+)\\s+(login|user)\\s+([^\\s]+)\\s+password\\s+(\"([^\"]+)\"|([^\\s]+))(\\s+port\\s+([\\d]+))?.*$");
+            // groups:                1            2               3                        4  5      5   6       6 7            8      8
+     static final int MACHINE_GROUP = 1;
+     static final int USER_GROUP = 3;
+     static final int QUOTED_PASSWORD_GROUP = 5;
+     static final int UNQUOTED_PASSWORD_GROUP = 6;
+     static final int PORT_GROUP = 8;
+             
     /* (non-Javadoc)
      * @see com.sas.unravl.auth.CredentialsProvider#getCredentials(java.lang.String, java.lang.String, java.lang.String, boolean)
      */
     @Override
-    public HostCredentials getHostCredentials(String host, String login, String password,
-            boolean mock) throws FileNotFoundException, IOException {
+    public HostCredentials getHostCredentials(String hostPort, String login, String password,
+                boolean mock) throws FileNotFoundException, IOException {
 
         if (mock)
             return mockCredentials();
@@ -55,7 +72,7 @@ public class NetrcCredentialsProvider extends AbstractCredentialsProvider implem
                 return credentials(login, password);
         }
 
-        // Locate the netrc config file with credentials
+        // Locate the netrc config file that contains credentials for hosts 
         File netrc = new File(".netrc"); // look in current dir first
         if (!netrc.exists())
             netrc = new File("_netrc"); // possible Windows file name, in current dir
@@ -67,13 +84,16 @@ public class NetrcCredentialsProvider extends AbstractCredentialsProvider implem
         if (!netrc.exists())
            return null;
 
+        // split host:port into its parts. :port is optional
+        String host = host(hostPort);
+        String port = port(hostPort);
         // Note: We can read and cache all the credentials, but that
         // is a security issue; we should probably encrypt the cached content.
         // Also, if we do cache the file content, we would still have to check
-        // the modification timestamp of the file, in case it has been updated since
+        // the modification time stamp of the file, in case it has been updated since
         // we cached the content.
         // Also, the loop below would need to read all rows, not stop when a
-        // match is found.
+        // match is found. So we don't cache and simply read the file each time it is needed
         BufferedReader reader = null;
         reader = new BufferedReader(new FileReader(netrc));
         try {
@@ -81,11 +101,12 @@ public class NetrcCredentialsProvider extends AbstractCredentialsProvider implem
                     .readLine()) {
                 Matcher m = NETRC.matcher(line);
                 if (m.matches()) {
-                    String netrchost = m.group(1);
-                    if (host.equals(netrchost)) {
-                        if (login == null || m.group(2).equals(login)) {
-                            login = m.group(2);
-                            password = m.group(3);
+                    String netrchost = m.group(MACHINE_GROUP);
+                    String netrcport = m.group(PORT_GROUP);
+                    if (host.equals(netrchost) && Objects.equals(port, netrcport)) {
+                        if (login == null || m.group(USER_GROUP).equals(login)) {
+                            login = m.group(USER_GROUP);
+                            password = password(m);
                             return credentials(login, password);
                         }
                     }
@@ -96,5 +117,13 @@ public class NetrcCredentialsProvider extends AbstractCredentialsProvider implem
                 reader.close();
         }
         return null;
+    }
+
+    private String password(Matcher m) {
+        if (m.end(QUOTED_PASSWORD_GROUP) > m.start(QUOTED_PASSWORD_GROUP))
+            return m.group(QUOTED_PASSWORD_GROUP);
+        if (m.end(UNQUOTED_PASSWORD_GROUP) > m.start(UNQUOTED_PASSWORD_GROUP))
+            return m.group(UNQUOTED_PASSWORD_GROUP);
+        throw new AssertionError("Regular expression did not match password in .netrc line.");
     }
 }

--- a/src/test/data/.netrc
+++ b/src/test/data/.netrc
@@ -1,0 +1,13 @@
+# Test data for TestNetrcCredentials JUnit test
+#
+# Basic credentials lookup for hostname:
+machine simple.host.com login test.user.a password test.user.a-secret
+#
+# Lookup credentials for host:port such as host.port8080.com:8080:
+machine host.withport8080.com user test.user.b password test.user.b-secret port 8080
+#
+# Test that extra whitespace is allowed
+  	machine    host.whitespace.com    user test.user.c    	  password 	test.user.c-secret
+#
+# test a password with spaces
+ machine host.special.com user test.user.d password "test.user.d password"  

--- a/src/test/java/com/sas/unrav/auth/test/TestNetrcCredentials.java
+++ b/src/test/java/com/sas/unrav/auth/test/TestNetrcCredentials.java
@@ -1,0 +1,92 @@
+// Copyright (c) 2015, SAS Institute Inc., Cary, NC, USA, All Rights Reserved
+package com.sas.unrav.auth.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sas.unravl.UnRAVLException;
+import com.sas.unravl.UnRAVLRuntime;
+import com.sas.unravl.auth.HostCredentials;
+import com.sas.unravl.auth.NetrcCredentialsProvider;
+import com.sas.unravl.util.Json;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TestNetrcCredentials {
+
+    @Parameters(name = "{index} host {0}, expect user {1}, password {2}")
+    public static Collection<Object[]> testCases() {
+        
+        return Arrays.asList(new Object[][] { //@formatter:off
+                // this test data should match src/test/netrc/.netrc
+                new String[] {"simple.host.com","test.user.a", "test.user.a-secret"},
+                new String[] {"host.withport8080.com:8080", "test.user.b", "test.user.b-secret"},
+                new String[] {"host.whitespace.com", "test.user.c", "test.user.c-secret"},
+                new String[] {"host.special.com", "test.user.d", "test.user.d password"},
+                });
+    } //@formatter:on
+
+    static String userHome = null;
+
+    @BeforeClass
+    public static void beforeClass() {
+        // Save current user.home, then run with a temporary user.home
+        // to pick up the test .netrc file
+
+        userHome = System.getProperty("user.home");
+        File tempUser = new File("src/test/data");
+        if (tempUser.exists())
+            System.setProperty("user.home", tempUser.getAbsolutePath());
+        else
+            userHome = null;
+    }
+
+    UnRAVLRuntime rt = new UnRAVLRuntime();
+    String hostName;
+    String expectedUserName;
+    String expectedPassword;
+
+    public TestNetrcCredentials(String hostName, String expectedUserName, String expectedPassword) {
+        this.hostName = hostName;
+        this.expectedUserName = expectedUserName;
+        this.expectedPassword = expectedPassword;
+    }
+
+    @Test
+    public void testNetrcCredentials() throws UnRAVLException, IOException {
+
+        if (userHome == null)
+            fail(String
+                    .format("no src/test/netrc directory relative to current directory %s",
+                            System.getProperty("user.dir")));
+
+        NetrcCredentialsProvider nc = new NetrcCredentialsProvider();
+        nc.setRuntime(rt);
+
+        ObjectNode node = (ObjectNode) Json.parse("{ \"basic\" : true }");
+        HostCredentials cred = nc.getHostCredentials(hostName, node,
+                false);
+        assertEquals(expectedUserName, cred.getUserName());
+        assertEquals(expectedPassword, cred.getPassword());
+
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        System.setProperty("user.home", userHome);
+    }
+
+}


### PR DESCRIPTION
Implement issue #28 
* allow passwords with whitespace by using quoted characters
* allow a port in .netrc
* allow using the key `user` instead of `login`

See updated `doc/Authentication.md`