### PR TITLE
catch more RestTemplate exceptions; 404 and 4xx

### DIFF
--- a/src/test/scripts/404.json
+++ b/src/test/scripts/404.json
@@ -1,0 +1,5 @@
+[
+  { "GET" : "http://www.no-such-host-name-matches-this-so-we-expect-404.com",
+    "assert" : { "status" : 404 }
+  }
+]


### PR DESCRIPTION
Catch exceptions that RestTemplate may throw and convert
them into 404 or 400 status codes.