### PR TITLE
more rubust handling of unwrapped data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .project
 .gradle
 /bin/
+temp.json

--- a/src/main/java/com/sas/unravl/ApiCall.java
+++ b/src/main/java/com/sas/unravl/ApiCall.java
@@ -301,6 +301,9 @@ public class ApiCall {
                     throw new UnRAVLException(
                             "Could not instantiate extractor " + key
                                     + " using class " + ec.getName(), e1);
+                } catch (RuntimeException e1) {
+                    throw new UnRAVLException(
+                            e1.getMessage(), e1);
                 }
             }
         } finally {

--- a/src/main/java/com/sas/unravl/util/Json.java
+++ b/src/main/java/com/sas/unravl/util/Json.java
@@ -384,4 +384,14 @@ public class Json {
         return result;
     }
 
+    // Convert a Java Map to a JSON ObjectNode
+    public static ObjectNode wrap(@SuppressWarnings("rawtypes") Map val) {
+        return mapper.valueToTree(val);
+    }
+
+
+    // Convert a Java List to a JSON ArrayNode
+    public static ObjectNode wrap(@SuppressWarnings("rawtypes") List val) {
+        return mapper.valueToTree(val);
+    }
 }

--- a/src/test/scripts/fail/extract-links-from-non-json.json
+++ b/src/test/scripts/fail/extract-links-from-non-json.json
@@ -1,0 +1,7 @@
+
+    {   "name" : "expect error; links \"from\" value is not JSON or a Map",
+        "bind" : [ { "groovy":  {"notJson" : "[0,1,2,3,4]" } },
+                   { "links" : "echo", "unwrap" : true, "from" : "notJson" }
+                 ]
+    }
+    

--- a/src/test/scripts/fail/links-fail-extract-from-text-body.json
+++ b/src/test/scripts/fail/links-fail-extract-from-text-body.json
@@ -1,0 +1,5 @@
+
+    {   "name" : "expect error; value not JSON or a Map",
+        "body" : { "text" : [ "this POST body", "consists of two lines" ] },
+        "bind" : { "links" : "echo", "unwrap" : true, "from" : "requestBody" }
+    }


### PR DESCRIPTION
Fix LinksExtractor so it can work with unwrapped JSON.
A few other minor bug fixes.
Add fail tests to validate correct error messages for
non-JSON, non-Map data for links extractor.
