### PR TITLE
ensure modified auth headers are passed to RestTemplate

### DIFF
--- a/src/main/java/com/sas/unravl/auth/BasicAuth.java
+++ b/src/main/java/com/sas/unravl/auth/BasicAuth.java
@@ -16,6 +16,7 @@ import java.net.URISyntaxException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.message.BasicHeader;
+import org.apache.log4j.Logger;
 
 /**
  * An auth element which provides basic authentication. This authenticates by
@@ -52,6 +53,7 @@ import org.apache.http.message.BasicHeader;
 @UnRAVLAuthPlugin("basic")
 public class BasicAuth extends BaseUnRAVLAuth {
 
+    private static final Logger logger = Logger.getLogger(BasicAuth.class);
     private boolean mock; // JSON spec contains "mock" : true, then mock out the
                           // responses
 
@@ -108,6 +110,7 @@ public class BasicAuth extends BaseUnRAVLAuth {
         // script
         getScript().addRequestHeader(
                 new BasicHeader("Authorization", "Basic " + creds));
+        logger.info("\"basic\" auth added 'Authorization: Basic ******' header");
     }
 
 }

--- a/src/main/java/com/sas/unravl/auth/CentralAuthenticationServiceAuth.java
+++ b/src/main/java/com/sas/unravl/auth/CentralAuthenticationServiceAuth.java
@@ -145,6 +145,7 @@ public class CentralAuthenticationServiceAuth extends BaseUnRAVLAuth {
     private String serviceTicket(String location, String serviceTicket)
             throws UnsupportedEncodingException {
         String encodedTicket = Text.urlEncode(serviceTicket);
+        logger.info("\"cas\" authentication added service ticket= query parameter to request URL.");
         if (location.indexOf('?') == -1)
             return location + "?ticket=" + encodedTicket;
         else


### PR DESCRIPTION
Also log (info) when "basic" adds an Authentication header.
This does not log the actual auth value (for security).
Also log (inf) when "cas" auth adds a ticket= query parameter.
