### PR TITLE
Allow redirect for HEAD

### DIFF
--- a/src/main/java/com/sas/unravl/ApiCall.java
+++ b/src/main/java/com/sas/unravl/ApiCall.java
@@ -778,14 +778,14 @@ public class ApiCall {
                 contentType.toString()) };
         if (script.bodyIsTextual(ct))
             try {
-                if (bytes == null) {
+                if (bytes == null || bytes.size() == 0) {
                     if (getMethod() != Method.HEAD)
                         logger.warn("Warning: Non-HEAD request returned a text Content-Type header but defines no body.");
                     return;
                 }
                 if (logger.isInfoEnabled()) {
                     logger.info(bodyLabel);
-                    if (script.bodyIsJson(ct)) {
+                    if (script.bodyIsJson(ct) && bytes.size() > 0) {
                         try {
                             ObjectMapper mapper = new ObjectMapper();
                             mapper.enable(SerializationFeature.INDENT_OUTPUT);


### PR DESCRIPTION
RestTemplate does not redirect HEAD calls when it receives 302 or other 3xx responses. This patch fixes that and restores the behavior seen with the previous Apache HTTP Client library.

Also includes a patch to not parse empty JSON responses when verbose logging is on (this will avoid an exception message in the log.)