### PR TITLE
Log failed assertions

### DIFF
--- a/src/main/java/com/sas/unravl/UnRAVLRuntime.java
+++ b/src/main/java/com/sas/unravl/UnRAVLRuntime.java
@@ -479,4 +479,10 @@ public class UnRAVLRuntime {
         env.remove(key);
     }
 
+    public void reset() {
+        failedAssertionCount = 0;
+        calls.clear();
+        canceled = false;
+    }
+
 }

--- a/src/main/java/com/sas/unravl/assertions/JUnitWrapper.java
+++ b/src/main/java/com/sas/unravl/assertions/JUnitWrapper.java
@@ -161,6 +161,7 @@ public class JUnitWrapper {
                 rt.execute(scriptFile);
                 for (ApiCall call : rt.getApiCalls()) {
                     if (call.getFailedAssertions().size() > 0)
+                        printFailedAssertions(call);
                         throw new AssertionError("script " + scriptFile
                                 + " should have had 0 assertion failures.");
                 }
@@ -174,6 +175,13 @@ public class JUnitWrapper {
             throw new AssertionError(caught.getMessage());
         }
         return count;
+    }
+
+    private static void printFailedAssertions(ApiCall call) {
+        for (UnRAVLAssertion a : call.getFailedAssertions()) {
+            logger.warn("Failed assertion: " + a.getAssertion());
+        }
+        
     }
 
     /**

--- a/src/main/java/com/sas/unravl/assertions/JUnitWrapper.java
+++ b/src/main/java/com/sas/unravl/assertions/JUnitWrapper.java
@@ -54,7 +54,7 @@ public class JUnitWrapper {
     /**
      * Run scripts in the directory if the file names match the pattern. This
      * will try to run all scripts, even if some fail. Each script runs
-     * independently in its own environment. 
+     * independently in its own environment.
      * 
      * TODO: Add boolean recursive option
      *
@@ -149,6 +149,8 @@ public class JUnitWrapper {
             Map<String, Object> env, String... scriptFileNames) {
         // for now, assume each command line arg is an UnRAVL script
         int count = 0;
+        if (runtime != null)
+            runtime.reset();
         Map<String, Object> newEnv = (env == null ? new HashMap<String, Object>()
                 : new HashMap<String, Object>(env));
         Throwable caught = null;
@@ -160,10 +162,11 @@ public class JUnitWrapper {
                 System.out.println("Run UnRAVL script " + scriptFile);
                 rt.execute(scriptFile);
                 for (ApiCall call : rt.getApiCalls()) {
-                    if (call.getFailedAssertions().size() > 0)
+                    if (call.getFailedAssertions().size() > 0) {
                         printFailedAssertions(call);
                         throw new AssertionError("script " + scriptFile
                                 + " should have had 0 assertion failures.");
+                    }
                 }
             } catch (Throwable t) {
                 logger.error(t.getMessage());
@@ -179,15 +182,15 @@ public class JUnitWrapper {
 
     private static void printFailedAssertions(ApiCall call) {
         for (UnRAVLAssertion a : call.getFailedAssertions()) {
-            logger.warn("Failed assertion: " + a.getAssertion());
+            logger.error("Failed assertion: " + a.getAssertion());
         }
-        
+
     }
 
     /**
      * Run all scripts in the directory, but expect an UnRAVLException. This
      * should be used to test invalid scripts. Each script runs independently in
-     * its own environment. 
+     * its own environment.
      * 
      * TODO: Add boolean recursive option
      *
@@ -204,7 +207,7 @@ public class JUnitWrapper {
     /**
      * Run all scripts in the directory which match a pattern, but expect an
      * UnRAVLException. This should be used to test invalid scripts. Each script
-     * runs independently in its own environment. 
+     * runs independently in its own environment.
      * 
      * TODO: Add boolean recursive option
      *

--- a/src/test/java/com/sas/unravl/test/TestScripts.java
+++ b/src/test/java/com/sas/unravl/test/TestScripts.java
@@ -2,11 +2,14 @@
 package com.sas.unravl.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.sas.unravl.ApiCall;
 import com.sas.unravl.UnRAVLRuntime;
 import com.sas.unravl.assertions.JUnitWrapper;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,32 +30,31 @@ public class TestScripts {
                 "GoogleEverestElevation.json");
     }
 
-
-    @Test(expected=AssertionError.class)
+    @Test(expected = AssertionError.class)
     public void testScriptsBadDir() {
         JUnitWrapper.runScriptsInDirectory(env(), "no-such/directory");
     }
-    
 
     @Test
     public void testScriptsWithRuntime() {
         UnRAVLRuntime runtime = new UnRAVLRuntime(env());
-        String[] scripts = new String[] { "src/test/scripts/parts/env.json", 
-                                          "src/test/scripts/parts/assert-env.json",
-                                          "src/test/scripts/parts/assert-junit.json"};
+        String[] scripts = new String[] { "src/test/scripts/parts/env.json",
+                "src/test/scripts/parts/assert-env.json",
+                "src/test/scripts/parts/assert-junit.json" };
         JUnitWrapper.runScriptFiles(runtime, scripts);
         // now verify that both used the same runtime
         List<ApiCall> calls = runtime.getApiCalls();
-        assertEquals(scripts.length, calls.size()); 
+        assertEquals(scripts.length, calls.size());
         for (ApiCall call : calls) {
             assertEquals(0, call.getFailedAssertions().size());
         }
-        // Warning: following is based on the values assigned in src/test/scripts/parts/env.json
+        // Warning: following is based on the values assigned in
+        // src/test/scripts/parts/env.json
         assertEquals(0, ((Number) runtime.binding("x")).intValue());
         assertEquals(1, ((Number) runtime.binding("y")).intValue());
         assertEquals(-1, ((Number) runtime.binding("z")).intValue());
     }
-    
+
     private Map<String, Object> env() {
         Map<String, Object> env = new HashMap<String, Object>();
         env.put("JUnit", Boolean.TRUE);
@@ -73,8 +75,40 @@ public class TestScripts {
         JUnitWrapper.runScriptsInDirectory(env(), "src/test/scripts/fail");
     }
 
-    @Test(expected=AssertionError.class)
+    @Test(expected = AssertionError.class)
     public void tryScriptsBadDir() {
         JUnitWrapper.tryScriptsInDirectory(env(), "no-such/directory");
+    }
+
+    @Test
+    public void assertionLogged1() {
+        assertionLogged("wrong-http-status-code.json", "this is an invalid assertion, this really returns 200");
+    }
+
+
+    @Test
+    public void assertionLogged2() {
+        assertionLogged("implicit.json", "count < 3");
+    }
+
+    public void assertionLogged(String testName, String expected) {
+        // Run a script which fails with a status assertion,
+        // and verify that the body of the exception gets printed to the console.
+        // This assumes the unit tests run with Log4J directed to the console.
+        PrintStream out = System.out;
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        PrintStream capturedOut = new PrintStream(os);
+        try {
+            System.setOut(capturedOut);
+            JUnitWrapper.runScriptsInDirectory(env(), "src/test/scripts/fail",
+                    testName);
+        } catch (Throwable t) {
+            capturedOut.flush();
+            String stdout = new String(os.toString());
+            assertTrue(stdout
+                    .contains(expected));
+        } finally {
+            System.setOut(out);
+        }
     }
 }

--- a/src/test/java/com/sas/unravl/test/TestScripts.java
+++ b/src/test/java/com/sas/unravl/test/TestScripts.java
@@ -2,14 +2,11 @@
 package com.sas.unravl.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import com.sas.unravl.ApiCall;
 import com.sas.unravl.UnRAVLRuntime;
 import com.sas.unravl.assertions.JUnitWrapper;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +52,7 @@ public class TestScripts {
         assertEquals(-1, ((Number) runtime.binding("z")).intValue());
     }
 
-    private Map<String, Object> env() {
+    static Map<String, Object> env() {
         Map<String, Object> env = new HashMap<String, Object>();
         env.put("JUnit", Boolean.TRUE);
         return env;
@@ -80,35 +77,4 @@ public class TestScripts {
         JUnitWrapper.tryScriptsInDirectory(env(), "no-such/directory");
     }
 
-    @Test
-    public void assertionLogged1() {
-        assertionLogged("wrong-http-status-code.json", "this is an invalid assertion, this really returns 200");
-    }
-
-
-    @Test
-    public void assertionLogged2() {
-        assertionLogged("implicit.json", "count < 3");
-    }
-
-    public void assertionLogged(String testName, String expected) {
-        // Run a script which fails with a status assertion,
-        // and verify that the body of the exception gets printed to the console.
-        // This assumes the unit tests run with Log4J directed to the console.
-        PrintStream out = System.out;
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        PrintStream capturedOut = new PrintStream(os);
-        try {
-            System.setOut(capturedOut);
-            JUnitWrapper.runScriptsInDirectory(env(), "src/test/scripts/fail",
-                    testName);
-        } catch (Throwable t) {
-            capturedOut.flush();
-            String stdout = new String(os.toString());
-            assertTrue(stdout
-                    .contains(expected));
-        } finally {
-            System.setOut(out);
-        }
-    }
 }


### PR DESCRIPTION
If an assertion fails in an UnRAVL test while running in JUnitWrapper, ensure the
assertion (JSON object) that failed is logged.