### PR TITLE
weave api call report and exceptions together

### DIFF
--- a/src/main/java/com/sas/unravl/UnRAVL.java
+++ b/src/main/java/com/sas/unravl/UnRAVL.java
@@ -37,7 +37,7 @@ import org.apache.log4j.Logger;
  * execute methods.
  * <p>
  * This class only executes a single UnRAVL test, represented by a JSON object.
- * It does not execute a JSON array of scripts; use UnRAVLRuntime 
+ * It does not execute a JSON array of scripts; use UnRAVLRuntime
  * 
  * TODO: This class is too large and does too much. Refactor.
  *
@@ -273,7 +273,11 @@ public class UnRAVL {
 
     public ApiCall run() throws UnRAVLException, IOException {
         ApiCall apiCall = new ApiCall(this);
-        return apiCall.run();
+        try {
+            return apiCall.run();
+        } finally {
+            apiCall.report(System.out);
+        }
     }
 
     /** Stop execution. */

--- a/src/main/java/com/sas/unravl/UnRAVLRuntime.java
+++ b/src/main/java/com/sas/unravl/UnRAVLRuntime.java
@@ -255,6 +255,7 @@ public class UnRAVLRuntime {
             } catch (UnRAVLAssertionException e) {
                 logger.error(e.getMessage() + " while running UnRAVL script "
                         + label);
+                
                 incrementFailedAssertionCount();
             } catch (RuntimeException rte) {
                 if (rte.getCause() instanceof UnRAVLException) { // tunneled
@@ -396,54 +397,12 @@ public class UnRAVLRuntime {
 
     public int report() {
         int failed = (calls.size() == 0 ? 1 : 0);
-        String separator = "";
         for (ApiCall call : calls) {
-            UnRAVL script = call.getScript();
-            String title = "Script '"
-                    + script.getName()
-                    + "' "
-                    + (call.getMethod() == null ? "<no method>" : script
-                            .getMethod().toString()) + " "
-                    + (call.getURI() == null ? "<no URI>" : call.getURI());
-            System.out.print(separator);
-            for (int i = title.length(); i > 0; i--)
-                System.out.print('-');
-            System.out.println();
-            System.out.println(title);
-
-            if (call.getException() != null) {
-                System.out.println("Caught exception running test "
-                        + script.getName() + " " + call.getMethod() + " "
-                        + call.getURI());
-                System.out.println(call.getException().getMessage());
-                System.out.flush();
-                failed++;
-            }
-            report(call.getPassedAssertions(), "Passed");
-            failed += report(call.getFailedAssertions(), "Failed");
-            report(call.getSkippedAssertions(), "Skipped");
-            separator = System.getProperty("line.separator").toString();
+            failed += call.getFailedAssertions().size();
         }
         if (canceled)
             System.out.println("UnRAVL script execution was canceled.");
         return failed;
-    }
-
-    private int report(List<UnRAVLAssertion> as, String label) {
-        if (as.size() > 0) {
-            System.out.println(as.size() + " " + label + ":");
-            for (UnRAVLAssertion a : as) {
-                System.out.println(label + " " + a.getStage().getName() + " "
-                        + a);
-                System.out.flush();
-                UnRAVLAssertionException e = a.getUnRAVLAssertionException();
-                if (e != null) {
-                    System.out.println(e.getClass().getName() + " "
-                            + e.getMessage());
-                }
-            }
-        }
-        return as.size();
     }
 
     public List<ApiCall> getApiCalls() {
@@ -468,7 +427,6 @@ public class UnRAVLRuntime {
             logger.warn("Replacing template " + name);
         }
         getTemplates().put(name, template);
-
     }
 
     public boolean hasTemplate(String name) {

--- a/src/test/scripts/fail/assertion-short-circuit.json
+++ b/src/test/scripts/fail/assertion-short-circuit.json
@@ -1,5 +1,5 @@
 [
-	{
+	{   "name" : "second of five assertions will fail, thus three skipped",
 		"assert":[
 			"true == true",
 			"true == false",
@@ -10,6 +10,7 @@
 
 	},
 	{
+		"name" : "Assertion in previous test failed, ths two assertions in this test should be skipped",
 		"assert":[
 			"assertNotNull('this test, therefore this assertion, should be skipped')",
 			"assertNotNull('as will this one')"


### PR DESCRIPTION
fix stdout so exceptions and API call reports are woven, so exceptions are more easily matched with the API call in std out (previously, reports were collected and printed at the end).