### PR TITLE
expand env vars in text request body

### DIFF
--- a/src/main/java/com/sas/unravl/generators/TextRequestBodyGenerator.java
+++ b/src/main/java/com/sas/unravl/generators/TextRequestBodyGenerator.java
@@ -38,6 +38,7 @@ public class TextRequestBodyGenerator extends BaseUnRAVLRequestBodyGenerator {
         JsonNode value = body.get("text");
         Text request = new Text(script, value);
         String requestBody = request.text();
+        requestBody = script.expand(requestBody);
         script.bind("requestBody", requestBody);
         return new ByteArrayInputStream(Text.utf8(requestBody));
     }


### PR DESCRIPTION
The `"text"` body generator was not expanding {var} strings from the UnRAVL environment.
Added a call to expand this. I probably should add an `"expand" : false` option
for this as well as the the `"json"` body generator.