### PR TITLE
Mock rest service server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     compile group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
     testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: jacksonVersion
     testCompile group: 'junit', name: 'junit', version: junitVersion
+    testCompile group: 'org.springframework', name: 'spring-test', version: springVersion
 }
 
 task copyDeps(type: Copy) {

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,12 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>org.springframework</groupId>
+         <artifactId>spring-test</artifactId>
+         <version>${spring.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>com.google.guava</groupId>
          <artifactId>guava</artifactId>
          <version>${quava.version}</version>

--- a/src/main/java/com/sas/unravl/UnRAVLRuntime.java
+++ b/src/main/java/com/sas/unravl/UnRAVLRuntime.java
@@ -12,7 +12,6 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
 import com.sas.unravl.annotations.UnRAVLAssertionPlugin;
 import com.sas.unravl.annotations.UnRAVLExtractorPlugin;
-import com.sas.unravl.assertions.UnRAVLAssertion;
 import com.sas.unravl.assertions.UnRAVLAssertionException;
 import com.sas.unravl.generators.UnRAVLRequestBodyGenerator;
 import com.sas.unravl.util.Json;

--- a/src/main/java/com/sas/unravl/assertions/JUnitWrapper.java
+++ b/src/main/java/com/sas/unravl/assertions/JUnitWrapper.java
@@ -220,6 +220,11 @@ public class JUnitWrapper {
      */
     public static void tryScriptsInDirectory(Map<String, Object> env,
             String directoryName, String pattern) {
+        tryScriptsInDirectory(null, env, directoryName, pattern);
+    }
+
+    public static void tryScriptsInDirectory(UnRAVLRuntime runtime,
+            Map<String, Object> env, String directoryName, String pattern) {
         File dir = new File(directoryName);
         ArrayList<String> fileNames = new ArrayList<String>();
         FilenameFilter filter = pattern == null ? unravlScriptFile
@@ -230,7 +235,7 @@ public class JUnitWrapper {
                 if (!file.isDirectory())
                     fileNames.add(file.getAbsolutePath());
             }
-            int count = JUnitWrapper.tryScriptFiles(env,
+            int count = JUnitWrapper.tryScriptFiles(runtime == null ? new UnRAVLRuntime(env) : runtime, 
                     fileNames.toArray(new String[fileNames.size()]));
             System.out.println(String.format("Tried %s scripts in %s%s", count,
                     directoryName, pattern == null ? "" : " matching pattern "
@@ -253,12 +258,16 @@ public class JUnitWrapper {
      */
     public static int tryScriptFiles(Map<String, Object> env,
             String... scriptFileNames) {
+        return tryScriptFiles(new UnRAVLRuntime(env), scriptFileNames);
+    }
+
+    public static int tryScriptFiles(UnRAVLRuntime rt,
+            String... scriptFileNames) {
         int count = 0;
-        // for now, assume each command line arg is an UnRAVL script
         for (String scriptFile : scriptFileNames) {
             try {
                 count++;
-                UnRAVLRuntime runtime = new UnRAVLRuntime(env);
+                UnRAVLRuntime runtime = rt == null ? new UnRAVLRuntime() : rt;
                 runtime.execute(scriptFile);
 
                 if (runtime.getFailedAssertionCount() > 0) {

--- a/src/main/java/com/sas/unravl/auth/AbstractCredentialsProvider.java
+++ b/src/main/java/com/sas/unravl/auth/AbstractCredentialsProvider.java
@@ -56,9 +56,16 @@ abstract public class AbstractCredentialsProvider implements
             boolean mock) throws IOException {
         if (mock)
             return mockCredentials();
-        String userName = Json.stringFieldOr(auth, "login", null);
-        String password = Json.stringFieldOr(auth, "password", null);
+        String userName = credentialValue(auth, "login");
+        if (userName == null)
+            userName = credentialValue(auth, "user");
+        String password = credentialValue(auth, "password");
         return getHostCredentials(host, userName, password, mock);
+    }
+
+    private String credentialValue(ObjectNode auth, String key) {
+        String val =Json.stringFieldOr(auth, key, null);
+        return val == null ? null : runtime.expand(val);
     }
 
     /**

--- a/src/main/java/com/sas/unravl/auth/BasicAuth.java
+++ b/src/main/java/com/sas/unravl/auth/BasicAuth.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, SAS Institute Inc., Cary, NC, USA, All Rights Reserved
 package com.sas.unravl.auth;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sas.unravl.ApiCall;
 import com.sas.unravl.UnRAVL;
@@ -72,10 +73,13 @@ public class BasicAuth extends BaseUnRAVLAuth {
                         "basic auth requires an HTTP method and URI");
             // TODO: allow the value to be a string; use that host name or
             // location for credential lookup
-            boolean enabled = Json.firstFieldValue(getScriptlet())
-                    .booleanValue();
-            if (!enabled)
+            JsonNode authVal = Json.firstFieldValue(getScriptlet());
+            if (!authVal.isBoolean()) {
+                throw new UnRAVLException("Value of \"auth\" must be boolean. Found: " + authVal);
+            }
+            if (!authVal.booleanValue())
                 return;
+            
             if (getScriptlet().get("mock") != null)
                 mock = getScriptlet().get("mock").booleanValue();
             // Note: the URI should already be expanded at this point
@@ -110,7 +114,7 @@ public class BasicAuth extends BaseUnRAVLAuth {
         // script
         getScript().addRequestHeader(
                 new BasicHeader("Authorization", "Basic " + creds));
-        logger.info("\"basic\" auth added 'Authorization: Basic ******' header");
+        logger.info("\"basic\" auth added 'Authorization: Basic ********' header");
     }
 
 }

--- a/src/main/java/com/sas/unravl/auth/NetrcCredentialsProvider.java
+++ b/src/main/java/com/sas/unravl/auth/NetrcCredentialsProvider.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
  * machine <em>qualified.hostname</em> login <em>userid-for-host</em> password <em>password-for-host</em> port <em>port-number</em>
  * </pre>
  * <p>
- * Items must appeaqr in this order. You may use <code>user</code> instead of
+ * Items must appear in this order. You may use <code>user</code> instead of
  * <code>login</code>.
  * </p>
  * <p>

--- a/src/test/java/com/sas/unravl/test/TestScriptsWithMockServer.java
+++ b/src/test/java/com/sas/unravl/test/TestScriptsWithMockServer.java
@@ -1,0 +1,126 @@
+// Copyright (c) 2014, SAS Institute Inc., Cary, NC, USA, All Rights Reserved
+package com.sas.unravl.test;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.sas.unravl.UnRAVLException;
+import com.sas.unravl.UnRAVLPlugins;
+import com.sas.unravl.UnRAVLRuntime;
+import com.sas.unravl.assertions.JUnitWrapper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * These tests use a RestTemplate and Spring MockRestServiceServer. The scripts
+ * are all located in the src/test/scripts/mock directory.
+ * <p>
+ * UnRAVL scripts in the src/test/scripts/mock/fail directory should fail with
+ * assertion errors.
+ * 
+ * @author David.Biesack@sas.com
+ */
+public class TestScriptsWithMockServer extends TestBase {
+
+    private static final String SRC_TEST_SCRIPTS_MOCK = "src/test/scripts/mock";
+    private static final String SRC_TEST_SCRIPTS_MOCK_FAIL = SRC_TEST_SCRIPTS_MOCK + "/fail";
+    private RestTemplate restTemplate;
+    private MockRestServiceServer mockServer;
+
+    @Before
+    public void createMockServer() {
+        restTemplate = new RestTemplate();
+        setRestTemplate(restTemplate);
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+    }
+
+    static UnRAVLRuntime runtime;
+
+    private static void setRestTemplate(RestTemplate restTemplate) {
+        runtime = new UnRAVLRuntime();
+        UnRAVLPlugins plugins = runtime.getPlugins();
+        plugins.setRestTemplate(restTemplate);
+    }
+
+    @After
+    public void afterClass() {
+        setRestTemplate(null);
+    }
+
+    @Test
+    public void helloJson() throws UnRAVLException {
+
+        createHelloJsonMock();
+        JUnitWrapper.runScriptsInDirectory(runtime, SRC_TEST_SCRIPTS_MOCK,
+                "helloJson.json");
+        mockServer.verify();
+    }
+
+
+    @Test
+    public void helloJsonFail() throws UnRAVLException {
+        createHelloJsonMock();
+        JUnitWrapper.tryScriptsInDirectory(runtime, null,
+                SRC_TEST_SCRIPTS_MOCK_FAIL, "helloJson.json");
+
+    }
+
+    private void createHelloJsonMock() throws UnRAVLException {
+        mockServer
+                .expect(requestTo("/hello.json"))
+                .andRespond(
+                        withSuccess(
+                                mockJson(
+                                        "{ 'greeting' : 'Hello', 'addressee' : 'World' }")
+                                        .toString(), MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    public void helloText() throws UnRAVLException {
+        createHelloTextMock();
+        JUnitWrapper.runScriptsInDirectory(runtime, SRC_TEST_SCRIPTS_MOCK,
+                "helloText.json");
+
+        mockServer.verify();
+    }
+
+    @Test
+    public void helloTextFail() throws UnRAVLException {
+        createHelloTextMock();
+        JUnitWrapper.tryScriptsInDirectory(runtime, null,
+                SRC_TEST_SCRIPTS_MOCK_FAIL, "helloText.json");
+    }
+
+
+    private void createHelloTextMock() {
+        mockServer.expect(requestTo("/hello.txt")).andRespond(
+                withSuccess("Hello, World!", MediaType.TEXT_PLAIN));
+    }
+
+    @Test
+    public void binary() throws UnRAVLException {
+        createBinaryMock();
+        JUnitWrapper.runScriptsInDirectory(runtime, SRC_TEST_SCRIPTS_MOCK,
+                "binary.json");
+        mockServer.verify();
+    }
+
+    @Test
+    public void binaryFail() throws UnRAVLException {
+        createBinaryMock();
+        JUnitWrapper.tryScriptsInDirectory(runtime, null,
+                SRC_TEST_SCRIPTS_MOCK_FAIL, "binary.json");
+    }
+
+    private void createBinaryMock() {
+        mockServer.expect(requestTo("/binary.dat")).andRespond(
+                withSuccess(new String(new byte[] { 0, 1, 2, 3, 4, 5, 6 }),
+                        MediaType.APPLICATION_OCTET_STREAM));
+    }
+
+}

--- a/src/test/java/com/sas/unravl/test/TestSimplifyJsonBody.java
+++ b/src/test/java/com/sas/unravl/test/TestSimplifyJsonBody.java
@@ -16,7 +16,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestSimplifyJsonBody extends TestBase {

--- a/src/test/scripts/mock/binary.json
+++ b/src/test/scripts/mock/binary.json
@@ -1,0 +1,7 @@
+{
+   "name" : "mock /binary.dat returns 7 bytes [0,1,2,3,4,5,6]",
+   "GET" : "/binary.dat",
+   "assert" : [ { "binary" : [0,1,2,3,4,5,6] },
+                { "headers" : { "Content-Type" : "application/octet-stream" } }
+              ]
+}

--- a/src/test/scripts/mock/fail/binary.json
+++ b/src/test/scripts/mock/fail/binary.json
@@ -1,0 +1,5 @@
+{
+   "name" : "mock /binary.dat returns 7 bytes [0,1,2,3,4,5,6]. Thus, test test should fail",
+   "GET" : "/binary.dat",
+   "assert" : { "binary" : [1,2,3,4,5,6.7] }
+}

--- a/src/test/scripts/mock/fail/helloJson.json
+++ b/src/test/scripts/mock/fail/helloJson.json
@@ -1,0 +1,11 @@
+{
+   "name" : "expect assertion failure on json response body.",
+   "GET" : "/hello.json",
+   "assert" :   [ 
+     { "doc" : "This test script should fail because the mock server returns greeting 'Hello', not 'Goodbye'" },
+     { "json" :
+       { "greeting" : "Goodbye",
+         "addressee" : "World" }
+     }
+   ]
+}

--- a/src/test/scripts/mock/fail/helloText.json
+++ b/src/test/scripts/mock/fail/helloText.json
@@ -1,0 +1,6 @@
+
+{
+   "name" : "mock /hello.txt returns 'Hello, World!'. Thus, this test should fail",
+   "GET" : "/hello.txt",
+   "assert" : { "text" : "Hello, Wally World!" }
+}

--- a/src/test/scripts/mock/helloJson.json
+++ b/src/test/scripts/mock/helloJson.json
@@ -1,0 +1,10 @@
+{
+   "name" : "mock /hello.son returns 'Hello' 'World'",
+   "GET" : "/hello.json",
+   "assert" : [ { "json" :
+                   { "greeting" : "Hello",
+                     "addressee" : "World" } 
+                   },
+                { "headers" : { "Content-Type" : "application/json" } }
+              ]
+}

--- a/src/test/scripts/mock/helloText.json
+++ b/src/test/scripts/mock/helloText.json
@@ -1,0 +1,8 @@
+
+{
+   "name" : "mock /hello.txt returns 'Hello, World!'",
+   "GET" : "/hello.txt",
+   "assert" : [ { "text" : "Hello, World!" },
+                { "headers" : { "Content-Type" : "text/plain" } }
+              ]
+}


### PR DESCRIPTION
Fix a few bugs in auth/headers - defer env expansion in headers until ApiCall (after evaluating `"env"`).
Use Spring mock server, to allow more script-based unit tests
