### PR TITLE
Key subst

### DIFF
--- a/src/main/java/com/sas/unravl/util/Json.java
+++ b/src/main/java/com/sas/unravl/util/Json.java
@@ -106,7 +106,7 @@ public class Json {
                     ObjectNode from = (ObjectNode) node;
                     ObjectNode to = new ObjectNode(jnf);
                     for (Map.Entry<String, JsonNode> f : Json.fields(from)) {
-                        to.set(f.getKey(), this.apply(f.getValue()));
+                        to.set(script.expand(f.getKey()), this.apply(f.getValue()));
                     }
                     return to;
                 } else

--- a/src/test/java/com/sas/unravl/test/TestBase.java
+++ b/src/test/java/com/sas/unravl/test/TestBase.java
@@ -12,6 +12,15 @@ import org.junit.Test;
 
 public class TestBase {
 
+    protected static final String WHO_VAL = "hackers";
+    protected static final Integer WHICH_VAL = Integer.valueOf(16);
+    protected static final String WHERE_VAL = "API";
+    protected static final String TIME_VAL = "Mon, Aug 4, 2014";
+    protected static final String WHO_KEY = "who";
+    protected static final String WHICH_KEY = "which";
+    protected static final String WHERE_KEY = "where";
+    protected static final String TIME_KEY = "time";
+
     public static UnRAVL scriptFixture() {
         UnRAVLRuntime r = new UnRAVLRuntime(envFixture());
         UnRAVL script = new UnRAVL(r);
@@ -34,10 +43,10 @@ public class TestBase {
 
     public static HashMap<String, Object> envFixture() {
         HashMap<String, Object> env = new HashMap<String, Object>();
-        env.put("time", "Mon, Aug 4, 2014");
-        env.put("where", "API");
-        env.put("which", Integer.valueOf(16));
-        env.put("who", "hackers");
+        env.put(TIME_KEY, TIME_VAL);
+        env.put(WHERE_KEY, WHERE_VAL);
+        env.put(WHICH_KEY, WHICH_VAL);
+        env.put(WHO_KEY, WHO_VAL);
         return env;
     }
 

--- a/src/test/java/com/sas/unravl/test/TestExpand.java
+++ b/src/test/java/com/sas/unravl/test/TestExpand.java
@@ -31,15 +31,19 @@ public class TestExpand extends TestBase {
     public void testMap() throws UnRAVLException {
         UnRAVL script = TestBase.scriptFixture();
         String in = "{ 's' : 'string', 'b' : true, 'i' : 123, 'd': 3.14159, "
-                + " 'a' : [ '{time}', 'is the time for {which}', '{who} to come to the aid', 'of their {where}' ],"
-                + " 'o' : { 'x' : '{which} {where}s' } }";
-        JsonNode from = TestBase.mockJson(in);
-        String out = script.expand(in);
-        JsonNode expected = TestBase.mockJson(out);
-        JsonNode to = Json.expand(from, script);
-        assertEquals(expected, to);
+                + " '{unboundVar|a}' : [ '{" + TIME_KEY + "}', 'is the time for {" + WHICH_KEY + "}', '{" + WHO_KEY + "} to come to the aid', 'of their {" + WHERE_KEY + "}' ],"
+                + " '{" + WHERE_KEY + "}' : { 'x' : '{" + WHICH_KEY + "} {" + WHERE_KEY + "}s' } }";
+
+        String outExpected = "{ 's' : 'string', 'b' : true, 'i' : 123, 'd': 3.14159, "
+                + " 'a' : [ '" + TIME_VAL + "', 'is the time for " + WHICH_VAL + "', '" + WHO_VAL + " to come to the aid', 'of their " + WHERE_VAL + "' ],"
+                + " '" + WHERE_VAL + "' : { 'x' : '" + WHICH_VAL + " " + WHERE_VAL + "s' } }";
+        JsonNode actual = Json.expand(TestBase.mockJson(in), script);
+        System.out.println(actual);
+        JsonNode expected = TestBase.mockJson(outExpected);
+        assertEquals(expected, actual);
     }
 
+    
     // No conditional assignment for 'env' binding
     @Test
     public void testNoConditionalAssignmentForEnvBinding()

--- a/src/test/scripts/expand.json
+++ b/src/test/scripts/expand.json
@@ -1,0 +1,13 @@
+{
+     "name" : "test env variable expansion",
+     "env" : { "key" : "issue61",
+               "value" : "Perform substitution in names",
+               "actual" : { "{key}" : "{value}" },
+               "expected" : { "issue61" : "Perform substitution in names" }
+              },
+     "assert" : [ "actual == expected",
+                  "actual.toString().contains(key)",
+                  "actual.toString().contains(value)",
+                  "actual.issue61.textValue() == value"
+                  ]
+}


### PR DESCRIPTION
Fix for Issue #61 

That is, this test script should pass; `{key}` will be expanded into `issue61`
{
     "name" : "test env variable expansion",
     "env" : { "key" : "issue61",
               "value" : "Perform substitution in names",
               "actual" : { "{key}" : "{value}" },
               "expected" : { "issue61" : "Perform substitution in names" }
              },
     "assert" : [ "actual == expected",
                  "actual.toString().contains(key)",
                  "actual.toString().contains(value)",
                  "actual.issue61.textValue() == value"
                  ]
}
```