### PR TITLE
Version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This can be captured in JSON using the UnRAVL syntax
 This is a fully functioning UnRAVL script. Besides executing the call, UnRAVL will also validate
 that the call returns a 2xx level HTTP status code, indicating success in one form or another.
 
-However, that is not highly useful. 
+However, that is not highly useful.
 This particular REST call should return the JSON body:
 ```JSON
 {
@@ -95,7 +95,7 @@ the result matches the expected JSON and that the HTTP response is 200:
 }
 ```
 
-This shows invoking an API using the GET method. `"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"` are the allowed HTTP verbs. 
+This shows invoking an API using the GET method. `"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"` are the allowed HTTP verbs.
 For `POST`, `PUT` and `PATCH`, you can also pass a request body.
 
 Next, we verify the result with a set of assertions:
@@ -150,7 +150,7 @@ an alternate approach would be to perform more specific assertions for data elem
 
 UnRAVL scripts also have an *environment*, which is a set of name/value pairs or variables.
 You can set variables explicitly, or bind them based on the result of API calls.
-For example, the above binds the JSON response body to a JsonNode (using the 
+For example, the above binds the JSON response body to a JsonNode (using the
 [Jackson](https://github.com/FasterXML/jackson)
 library for JSON) named `response`. (See [`"json"`](doc/Bind.md#json)
 for details.) This variable may be used to compare nested
@@ -159,7 +159,7 @@ expression that must evaluate to true for the test to pass.
 (You can also use JavaScript.)
 Groovy expressions can walk JSON structures naturally by accessing object values
 by name, or array items by index. The `doubleValue()` method extracts
-the numeric value of a Jackson [NumericNode](https://fasterxml.github.io/jackson-databind/javadoc/2.2.0/com/fasterxml/jackson/databind/node/NumericNode.html) item. 
+the numeric value of a Jackson [NumericNode](https://fasterxml.github.io/jackson-databind/javadoc/2.2.0/com/fasterxml/jackson/databind/node/NumericNode.html) item.
 
 Most string values in UnRAVL scripts are subject to environment substitution
 which replaces substrings of the form `{varName}` with the value
@@ -171,6 +171,19 @@ To see the full syntax for UnRAVL scripts, refer to [Reference](doc/Reference.md
 
 ## Releases
 
+* [Release v1.1.0](https://github.com/sassoftware/unravl/releases/tag/v1.1.0)
+  * Added [OAuth2](doc/Authentication.md#uath2) authentication
+  * A script can disable inherited authentication
+  * UnRAVL variables are now expanded in JSON object keys, not just in
+    string values
+  * Added a [`"form"`](doc/Body.md#form) body generator
+  * Expand UnRAVL variables in `"basic"` authentication parameters
+  * UnRAVL now follows 3xx redirects for HEAD calls as well as GET calls
+  * Added an `"unwrap"` option for the [`"json"`](doc/Bind.md#json)
+    response extractor and the [`"links"` and `"hrefs"`](doc/Bind.md#links-and-hrefs )
+    extractors
+  * Added the[`"jsonPath"`](doc/Bind.md#jsonPath) body extractor
+  * Various bug fixes
 * [Release v1.0.0](https://github.com/sassoftware/unravl/releases/tag/v1.0.0)
   * Removed deprecated features (equals assertion)
   * Reduced dependency on JUnit. All behaviors, assertions, etc. do not depend on JUnit.

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'eclipse' // run './gradlew eclipse' to update Eclipse .classpath, then refresh Eclipse project
 
 group = 'com.sas'
-version = '1.1.0-SNAPSHOT'
+version = '1.1.0'
 
 description = "Uniform REST API Validation Language"
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.sas</groupId>
    <artifactId>sas.unravl</artifactId>
-   <version>1.1.0-SNAPSHOT</version>
+   <version>1.1.0</version>
    <description>Uniform REST API Validation Language  (UnRAVL) - a JSON DSL for validating REST APIs</description>
    <url>https://github.com/sassoftware/unravl</url>
    <inceptionYear>2014</inceptionYear>
@@ -77,8 +77,8 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <version>2.5.1</version>
             <configuration>
-               <source>1.6</source>
-               <target>1.6</target>
+               <source>1.7</source>
+               <target>1.7</target>
             </configuration>
          </plugin>
 

--- a/src/main/java/com/sas/unravl/ApiCall.java
+++ b/src/main/java/com/sas/unravl/ApiCall.java
@@ -181,7 +181,7 @@ public class ApiCall {
             return;
         }
         if (auth.isBoolean()) {
-            if (auth.booleanValue() ) {
+            if (auth.booleanValue()) {
                 throw new UnRAVLException(
                         "\"auth\" : true is invalid. Only \"auth\" : false is allowed (to disable inherited authentication.)");
             } else {
@@ -190,13 +190,13 @@ public class ApiCall {
             }
         }
         ObjectNode spec = null;
-        // If "auth" value is just a string and not an object, such as "auth" : "basic", 
+        // If "auth" value is just a string and not an object, such as "auth" :
+        // "basic",
         // convert to "auth" : { "basic" : true } to enable that auth type
-        if (auth.isTextual())  
-        {
+        if (auth.isTextual()) {
             spec = Json.jsonNodeFactory().objectNode();
             spec.put(auth.textValue(), true);
-        } else 
+        } else
             spec = Json.object(auth);
         String authKey = Json.firstFieldName(spec);
         Class<? extends UnRAVLAuth> authClass = getPlugins().getAuth().get(
@@ -467,7 +467,8 @@ public class ApiCall {
         } catch (IOException e) {
             throwException(e);
         }
-        // expand the URI after authenticating: OAuth2 or other auth may set env vars that should
+        // expand the URI after authenticating: OAuth2 or other auth may set env
+        // vars that should
         // be expanded in the URI
         setURI(script.expand(getURI()));
         // Use RequestCallback and ResponseExtractor
@@ -554,7 +555,8 @@ public class ApiCall {
         HttpHeaders headers = new HttpHeaders();
         for (Header h : requestHeaders) {
             String value = getScript().expand(h.getValue());
-            logger.info(String.format("Request header: %s: %s", h.getName(), possiblyMaskedHeaderValue(h)));
+            logger.info(String.format("Request header: %s: %s", h.getName(),
+                    possiblyMaskedHeaderValue(h)));
             headers.add(h.getName(), value);
         }
         return headers;
@@ -794,7 +796,7 @@ public class ApiCall {
             Header hs[] = mapHeaders(headers);
             for (Header h : hs) {
                 // Don't log easily decoded credentials
-                logger.info(h.getName() + ": " + possiblyMaskedHeaderValue(h) );
+                logger.info(h.getName() + ": " + possiblyMaskedHeaderValue(h));
             }
         }
         MediaType contentType = headers.getContentType();
@@ -834,7 +836,8 @@ public class ApiCall {
     }
 
     private String possiblyMaskedHeaderValue(Header h) {
-        return h.getName().equalsIgnoreCase(AUTHORIZATION) ? MASK : h.getValue();
+        return h.getName().equalsIgnoreCase(AUTHORIZATION) ? MASK : h
+                .getValue();
     }
 
     public UnRAVL getScript() {
@@ -860,10 +863,12 @@ public class ApiCall {
      *            the report destination
      */
     public void report(PrintStream out) {
-        UnRAVL script = getScript(); //@formatter:off
-        String title = "Script '" + script.getName() + "' "
+        UnRAVL script = getScript(); // @formatter:off
+        String title = "Script '"
+                + script.getName()
+                + "' "
                 + (getMethod() == null ? "<no method>" : getMethod().toString())
-                + " " + (getURI() == null ? "<no URI>" : getURI()); //@formatter:on
+                + " " + (getURI() == null ? "<no URI>" : getURI()); // @formatter:on
         out.println();
         for (int i = title.length(); i > 0; i--)
             out.print('-');
@@ -885,13 +890,11 @@ public class ApiCall {
         out.println(as.size() + " " + label + ":");
         if (as.size() > 0) {
             for (UnRAVLAssertion a : as) {
-                out.println(label + " " + a.getStage().getName() + " "
-                        + a);
+                out.println(label + " " + a.getStage().getName() + " " + a);
                 out.flush();
                 UnRAVLAssertionException e = a.getUnRAVLAssertionException();
                 if (e != null) {
-                    out.println(e.getClass().getName() + " "
-                            + e.getMessage());
+                    out.println(e.getClass().getName() + " " + e.getMessage());
                 }
             }
         }

--- a/src/main/java/com/sas/unravl/BaseUnRAVLPlugin.java
+++ b/src/main/java/com/sas/unravl/BaseUnRAVLPlugin.java
@@ -12,56 +12,70 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public abstract class BaseUnRAVLPlugin implements UnRAVLPlugin {
 
     /**
-     * Extract a boolean value from the current scriptlet. For example, the "basic"
-     * auth element 
+     * Extract a boolean value from the current scriptlet. For example, the
+     * "basic" auth element
+     * 
      * <pre>
      * { "auth" : { "basic" : true } }
      * </pre>
+     * 
      * can use this to get the boolean value named "basic"
-     * @param scriptlet the element inside an UnRAVL script
-     * @param optionName the name of the option
-     * @return true if th eoption was found and has the value true; otherwise false
-     * @throws UnRAVLException if the value is not a boolean
+     * 
+     * @param scriptlet
+     *            the element inside an UnRAVL script
+     * @param optionName
+     *            the name of the option
+     * @return true if th eoption was found and has the value true; otherwise
+     *         false
+     * @throws UnRAVLException
+     *             if the value is not a boolean
      */
-    protected static boolean booleanOption(ObjectNode scriptlet, String optionName)
-            throws UnRAVLException {
-                JsonNode val = scriptlet.get(optionName);
-                if (val == null)
-                    return false;
-                if (val.isBoolean())
-                    return val.booleanValue();
-                String msg = String.format(
-                        "%s option in %s must be a Boolean value; found %s",
-                        optionName, key(scriptlet), val);
-                throw new UnRAVLException(msg);
-            }
-    
+    protected static boolean booleanOption(ObjectNode scriptlet,
+            String optionName) throws UnRAVLException {
+        JsonNode val = scriptlet.get(optionName);
+        if (val == null)
+            return false;
+        if (val.isBoolean())
+            return val.booleanValue();
+        String msg = String.format(
+                "%s option in %s must be a Boolean value; found %s",
+                optionName, key(scriptlet), val);
+        throw new UnRAVLException(msg);
+    }
 
     /**
      * Extract a text value from the current scriptlet. For example, the "oath2"
-     * auth element 
+     * auth element
+     * 
      * <pre>
      * { "auth" : { "oath2" : "https://www.example.com/auth/token", "query" : "access_token" } }
      * </pre>
+     * 
      * can use this to get the boolean value named "access_token"
-     * @param scriptlet the element inside an UnRAVL script
-     * @param optionName the name of the option
-     * @param defaultValue value to return if the option is not present
-     * @return the string associated with the options name if found, else the default value
-     * @throws UnRAVLException if the value is not a text node
+     * 
+     * @param scriptlet
+     *            the element inside an UnRAVL script
+     * @param optionName
+     *            the name of the option
+     * @param defaultValue
+     *            value to return if the option is not present
+     * @return the string associated with the options name if found, else the
+     *         default value
+     * @throws UnRAVLException
+     *             if the value is not a text node
      */
-    protected String stringOption(ObjectNode scriptlet, String optionName, String defaultValue)
-            throws UnRAVLException {
-                JsonNode val = scriptlet.get(optionName);
-                if (val == null)
-                    return defaultValue;
-                if (val.isTextual())
-                    return val.textValue();
-                String msg = String.format(
-                        "%s option in %s must be a text value; found %s",
-                        optionName, key(scriptlet), val);
-                throw new UnRAVLException(msg);
-            }
+    protected String stringOption(ObjectNode scriptlet, String optionName,
+            String defaultValue) throws UnRAVLException {
+        JsonNode val = scriptlet.get(optionName);
+        if (val == null)
+            return defaultValue;
+        if (val.isTextual())
+            return val.textValue();
+        String msg = String.format(
+                "%s option in %s must be a text value; found %s", optionName,
+                key(scriptlet), val);
+        throw new UnRAVLException(msg);
+    }
 
     /**
      * Returns the name of this extractor. THis is the name (key) of the first

--- a/src/main/java/com/sas/unravl/UnRAVL.java
+++ b/src/main/java/com/sas/unravl/UnRAVL.java
@@ -265,7 +265,8 @@ public class UnRAVL {
             return;
         for (Map.Entry<String, JsonNode> h : Json.fields(headersNode)) {
             String string = h.getKey();
-            // Do not expand headers here; do so in ApiCall.mapHeaders(List<Header> requestHeaders)
+            // Do not expand headers here; do so in
+            // ApiCall.mapHeaders(List<Header> requestHeaders)
             // This method is called before "env" is evaluated,
             // so expansion here is premature.
             String val = h.getValue().asText();
@@ -288,12 +289,15 @@ public class UnRAVL {
         getRuntime().cancel();
     }
 
-
     /**
      * Bind a value within this script's environment. This will add a new
-     * binding if <var>varName</var> is not yet bound, or replace the old binding.
-     * @param varName the variable name
-     * @param value the variable value
+     * binding if <var>varName</var> is not yet bound, or replace the old
+     * binding.
+     * 
+     * @param varName
+     *            the variable name
+     * @param value
+     *            the variable value
      * @return this script, which allows chaining bind calls.
      * @see UnRAVLRuntime#bind(String, Object)
      */
@@ -304,7 +308,9 @@ public class UnRAVL {
 
     /**
      * Return the value bound to a variable in this script's environment
-     * @param varName the variable name
+     * 
+     * @param varName
+     *            the variable name
      * @return the value bound to the variable
      * @see UnRAVLRuntime#binding(String)
      */
@@ -312,11 +318,12 @@ public class UnRAVL {
         return getRuntime().binding(varName);
     }
 
-
     /**
      * Test if the value bound in this script's environment
-     * @param varName the variable name
-     * @return true iff the variable is bound 
+     * 
+     * @param varName
+     *            the variable name
+     * @return true iff the variable is bound
      * @see UnRAVLRuntime#bound(String)
      */
     public boolean bound(String varName) {

--- a/src/main/java/com/sas/unravl/UnRAVLPlugins.java
+++ b/src/main/java/com/sas/unravl/UnRAVLPlugins.java
@@ -70,8 +70,7 @@ public class UnRAVLPlugins {
      * @param credentialsProvider
      *            the instance which can get userid/password for a host
      */
-    public void setCredentialsProvider(
-            CredentialsProvider credentialsProvider) {
+    public void setCredentialsProvider(CredentialsProvider credentialsProvider) {
         this.credentialsProvider = credentialsProvider;
     }
 
@@ -194,20 +193,23 @@ public class UnRAVLPlugins {
     // that follows redirect for HEAD calls. The default
     // SimpleClientHttpRequestFactory only follows redirects
     // for GET.
-    // see http://stackoverflow.com/questions/29418583/follow-302-redirect-using-spring-resttemplate
-    private RestTemplate newRestTemplate()
-    {
-        RestTemplate rt = new RestTemplate(new SimpleClientHttpRequestFactory() {
-            @Override
-            protected void prepareConnection(HttpURLConnection connection, String httpMethod) throws IOException {
-                
-                super.prepareConnection(connection, httpMethod);
+    // see
+    // http://stackoverflow.com/questions/29418583/follow-302-redirect-using-spring-resttemplate
+    private RestTemplate newRestTemplate() {
+        RestTemplate rt = new RestTemplate(
+                new SimpleClientHttpRequestFactory() {
+                    @Override
+                    protected void prepareConnection(
+                            HttpURLConnection connection, String httpMethod)
+                            throws IOException {
 
-                if ("HEAD".equals(httpMethod)) {
-                    connection.setInstanceFollowRedirects(true);
-                }
-            }
-        });
+                        super.prepareConnection(connection, httpMethod);
+
+                        if ("HEAD".equals(httpMethod)) {
+                            connection.setInstanceFollowRedirects(true);
+                        }
+                    }
+                });
         return rt;
     }
 

--- a/src/main/java/com/sas/unravl/UnRAVLRuntime.java
+++ b/src/main/java/com/sas/unravl/UnRAVLRuntime.java
@@ -24,7 +24,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +68,9 @@ public class UnRAVLRuntime implements Cloneable {
 
     /**
      * Instantiate a new runtime with the given environment
-     * @param environment name/value bindings
+     * 
+     * @param environment
+     *            name/value bindings
      */
     public UnRAVLRuntime(Map<String, Object> environment) {
         configure();
@@ -80,13 +81,14 @@ public class UnRAVLRuntime implements Cloneable {
         bind("failedAssertionCount", Integer.valueOf(0));
         resetBindings();
     }
-    
 
     /**
-     * Instantiate a new runtime with the environment of the input runtime instance.
-     * The environment is copied, but the new runtime gets its own empty list
-     * of calls, scripts, and templates.
-     * @param runtime an existing Runtime (may not be null)
+     * Instantiate a new runtime with the environment of the input runtime
+     * instance. The environment is copied, but the new runtime gets its own
+     * empty list of calls, scripts, and templates.
+     * 
+     * @param runtime
+     *            an existing Runtime (may not be null)
      */
     public UnRAVLRuntime(UnRAVLRuntime runtime) {
         env = new LinkedHashMap<String, Object>();
@@ -277,7 +279,7 @@ public class UnRAVLRuntime implements Cloneable {
             } catch (UnRAVLAssertionException e) {
                 logger.error(e.getMessage() + " while running UnRAVL script "
                         + label);
-                
+
                 incrementFailedAssertionCount();
             } catch (RuntimeException rte) {
                 if (rte.getCause() instanceof UnRAVLException) { // tunneled
@@ -347,7 +349,8 @@ public class UnRAVLRuntime implements Cloneable {
      *
      * @param text
      *            an input string. May be null.
-     * @return the string, with environment variables replaced. Returns null if the input is null.
+     * @return the string, with environment variables replaced. Returns null if
+     *         the input is null.
      */
     public String expand(String text) {
         if (text == null)
@@ -360,9 +363,13 @@ public class UnRAVLRuntime implements Cloneable {
 
     /**
      * Bind a value within this runtime's environment. This will add a new
-     * binding if <var>varName</var> is not yet bound, or replace the old binding.
-     * @param varName variable name
-     * @param value variable value
+     * binding if <var>varName</var> is not yet bound, or replace the old
+     * binding.
+     * 
+     * @param varName
+     *            variable name
+     * @param value
+     *            variable value
      * @return this runtime, which allows chaining bind calls.
      */
     public UnRAVLRuntime bind(String varName, Object value) {
@@ -376,10 +383,11 @@ public class UnRAVLRuntime implements Cloneable {
         return this;
     }
 
-
     /**
      * Return the value bound to a variable in this runtime's environment
-     * @param varName the variable name
+     * 
+     * @param varName
+     *            the variable name
      * @return the value bound to the variable
      */
     public Object binding(String varName) {
@@ -388,16 +396,18 @@ public class UnRAVLRuntime implements Cloneable {
 
     /**
      * Test if the value bound in this script's environment
-     * @param varName the variable name
-     * @return true iff the variable is bound 
+     * 
+     * @param varName
+     *            the variable name
+     * @return true iff the variable is bound
      */
     public boolean bound(String varName) {
         return env.containsKey(varName);
     }
 
-
     /**
      * Call this when bindings have changed.
+     * 
      * @deprecated no longer needed. This method will be removed in 1.1.0
      */
     @Deprecated

--- a/src/main/java/com/sas/unravl/assertions/JUnitWrapper.java
+++ b/src/main/java/com/sas/unravl/assertions/JUnitWrapper.java
@@ -235,7 +235,8 @@ public class JUnitWrapper {
                 if (!file.isDirectory())
                     fileNames.add(file.getAbsolutePath());
             }
-            int count = JUnitWrapper.tryScriptFiles(runtime == null ? new UnRAVLRuntime(env) : runtime, 
+            int count = JUnitWrapper.tryScriptFiles(
+                    runtime == null ? new UnRAVLRuntime(env) : runtime,
                     fileNames.toArray(new String[fileNames.size()]));
             System.out.println(String.format("Tried %s scripts in %s%s", count,
                     directoryName, pattern == null ? "" : " matching pattern "

--- a/src/main/java/com/sas/unravl/auth/AbstractCredentialsProvider.java
+++ b/src/main/java/com/sas/unravl/auth/AbstractCredentialsProvider.java
@@ -64,7 +64,7 @@ abstract public class AbstractCredentialsProvider implements
     }
 
     private String credentialValue(ObjectNode auth, String key) {
-        String val =Json.stringFieldOr(auth, key, null);
+        String val = Json.stringFieldOr(auth, key, null);
         return val == null ? null : runtime.expand(val);
     }
 
@@ -105,14 +105,12 @@ abstract public class AbstractCredentialsProvider implements
         return new HostCredentials(runtime.expand(login),
                 runtime.expand(password));
     }
-    
-    protected HostCredentials credentials(String login, String password, String clientId, String clientSecret, String accessToken) {
-        return new OAuth2Credentials(
-                runtime.expand(login),
-                runtime.expand(password),
-                runtime.expand(clientId),
-                runtime.expand(clientSecret),
-                runtime.expand(accessToken));
+
+    protected HostCredentials credentials(String login, String password,
+            String clientId, String clientSecret, String accessToken) {
+        return new OAuth2Credentials(runtime.expand(login),
+                runtime.expand(password), runtime.expand(clientId),
+                runtime.expand(clientSecret), runtime.expand(accessToken));
     }
 
 }

--- a/src/main/java/com/sas/unravl/auth/BasicAuth.java
+++ b/src/main/java/com/sas/unravl/auth/BasicAuth.java
@@ -78,11 +78,12 @@ public class BasicAuth extends BaseUnRAVLAuth {
             // location for credential lookup
             JsonNode authVal = Json.firstFieldValue(getScriptlet());
             if (!authVal.isBoolean()) {
-                throw new UnRAVLException("Value of \"auth\" must be boolean. Found: " + authVal);
+                throw new UnRAVLException(
+                        "Value of \"auth\" must be boolean. Found: " + authVal);
             }
             if (!authVal.booleanValue())
                 return;
-            
+
             if (getScriptlet().get("mock") != null)
                 mock = getScriptlet().get("mock").booleanValue();
             // Note: the URI should already be expanded at this point

--- a/src/main/java/com/sas/unravl/auth/CentralAuthenticationServiceAuth.java
+++ b/src/main/java/com/sas/unravl/auth/CentralAuthenticationServiceAuth.java
@@ -33,12 +33,12 @@ import org.apache.http.message.BasicHeader;
 import org.apache.log4j.Logger;
 
 /**
- * An auth plugin which authenticates with Central Authentication Service. 
- * This authenticates to obtain a Ticket Granting Ticket
- * (TGT) using the user's credentials provided by the {@link CredentialsProvider}
- * which by default is the {@link NetrcCredentialsProvider}. This then uses that
- * TGT to obtain a Service Ticket for the current UnRAVL script API. Optionally,
- * credentials may be enclosed directly in the "cas" element.
+ * An auth plugin which authenticates with Central Authentication Service. This
+ * authenticates to obtain a Ticket Granting Ticket (TGT) using the user's
+ * credentials provided by the {@link CredentialsProvider} which by default is
+ * the {@link NetrcCredentialsProvider}. This then uses that TGT to obtain a
+ * Service Ticket for the current UnRAVL script API. Optionally, credentials may
+ * be enclosed directly in the "cas" element.
  * <p>
  * This auth element is specified via
  *
@@ -51,8 +51,10 @@ import org.apache.log4j.Logger;
  *
  * where <em>logon-URL</em> is a string containing the URL of the ticket
  * granting ticket authentication API, such as
+ * 
  * <pre>
- * { "cas" : "http://www.example.com/SASLogon/v1/tickets" }</pre>
+ * { "cas" : "http://www.example.com/SASLogon/v1/tickets" }
+ * </pre>
  * <p>
  * The service ticket is appended as a query parameter to the end of the URI as
  * <code>&amp;ticket=&lt;<em>service-ticket</em>&gt;</code> or

--- a/src/main/java/com/sas/unravl/auth/CredentialsProvider.java
+++ b/src/main/java/com/sas/unravl/auth/CredentialsProvider.java
@@ -4,7 +4,6 @@ package com.sas.unravl.auth;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sas.unravl.UnRAVLRuntime;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 /**
@@ -19,20 +18,23 @@ public interface CredentialsProvider {
 
     /**
      * Get credentials for the host.
+     * 
      * @param host
      *            the host name or host:port string
      * @param auth
      *            The JsonNode containing the auth contents (usually login and
      *            password). Examples would be
+     * 
      *            <pre>
      *            { "basic" : true }
      *            { "oath2" : "https://www.example.com/auth/token" }
-     *            </pre>
+     * </pre>
      * @param mock
      *            if true, return mock credentials
-     * @return an object containing the user login name and password.
-     * This may be a {@link OAuth2Credentials} object if the credentials
-     * contain <code>clintId</code>, <code>clientPassword</code>, or <code>accessToken</code>
+     * @return an object containing the user login name and password. This may
+     *         be a {@link OAuth2Credentials} object if the credentials contain
+     *         <code>clintId</code>, <code>clientPassword</code>, or
+     *         <code>accessToken</code>
      * @throws IOException
      *             if we could not read the .netrc file
      */
@@ -56,11 +58,11 @@ public interface CredentialsProvider {
      *            if true, return mock credentials
      * @return an object containing the user login name and password
      * @throws IOException
-     *             if there is an I/O exception trying to read stored credentials
+     *             if there is an I/O exception trying to read stored
+     *             credentials
      */
     public abstract HostCredentials getHostCredentials(String host,
-            String userName, String password, boolean mock)
-            throws IOException;
+            String userName, String password, boolean mock) throws IOException;
 
     public void setRuntime(UnRAVLRuntime runtime);
 }

--- a/src/main/java/com/sas/unravl/auth/NetrcCredentialsProvider.java
+++ b/src/main/java/com/sas/unravl/auth/NetrcCredentialsProvider.java
@@ -153,7 +153,8 @@ public class NetrcCredentialsProvider extends AbstractCredentialsProvider {
                     if (login == null || lLogin.equals(login)) {
                         login = lLogin;
                         password = lPassword;
-                        if (lClientId != null || lClientSecret != null || lAccessToken != null)
+                        if (lClientId != null || lClientSecret != null
+                                || lAccessToken != null)
                             return credentials(login, password, lClientId,
                                     lClientSecret, lAccessToken);
                         else

--- a/src/main/java/com/sas/unravl/auth/OAuth2Auth.java
+++ b/src/main/java/com/sas/unravl/auth/OAuth2Auth.java
@@ -15,11 +15,8 @@ import com.sas.unravl.util.Json;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -29,44 +26,42 @@ import org.apache.http.message.BasicHeader;
 import org.apache.log4j.Logger;
 
 /**
- * An auth plugin which authenticates with OAuth2. This using the user's credentials provided by the
- * {@link CredentialsProvider} which by default is the {@link NetrcCredentialsProvider}.
+ * An auth plugin which authenticates with OAuth2. This using the user's
+ * credentials provided by the {@link CredentialsProvider} which by default is
+ * the {@link NetrcCredentialsProvider}.
  * <p>
  * This auth element is specified via
  *
  * <pre>
  * "auth" : { "oauth2" : <em>oauth-server-URL</em> }
- * "auth" : { "oauth2" : <em>oauth-server-URL</em>, <em>options</em> }
+ * "auth" : { "oauth2" : <em>oauth-server-URL</em>, <em>options</em>
  * </pre>
  * 
- * where <em>auth-token-URL</em> is a string containing the URL of the authorization server token
- * API, such as
+ * where <em>auth-token-URL</em> is a string containing the URL of the
+ * authorization server token API, such as
  * 
  * <pre>
  * { "oauth2" : "http://www.example.com/auth/token" }
  * </pre>
  * 
- * <h2>Options</h2> The "oath2" object supports several options to configure the OAUth2
- * authentication. See
- * <a href='https://github.com/sassoftware/unravl/blob/master/doc/Authentication.md#oauth2'>
- * Authentication: oauth2</a> for complete details.
+ * <h2>Options</h2> The "oath2" object supports several options to configure the
+ * OAUth2 authentication. See <a href=
+ * 'https://github.com/sassoftware/unravl/blob/master/doc/Authentication.md#oauth2'
+ * > Authentication: oauth2</a> for complete details.
  * <p>
  * This auth module may be accessed with either the name <code>"oauth2"</code>,
  * <code>"OAuth2"</code>, <code>"oauth"</code>, <code>"OAuth"</code>.
  *
  * @author DavidBiesack@sas.com
  */
-@UnRAVLAuthPlugin({"oauth", "oauth2", "OAuth", "OAuth2"})
-public class OAuth2Auth
-    extends BaseUnRAVLAuth
-{
+@UnRAVLAuthPlugin({ "oauth", "oauth2", "OAuth", "OAuth2" })
+public class OAuth2Auth extends BaseUnRAVLAuth {
 
     private static final String PARAMETER_KEY = "parameter";
     private static final String ACCESS_TOKEN = "access_token";
     private static final String BIND_ACCESS_TOKEN_KEY = "bindAccessToken";
     private static final String DEFAULT_ACCESS_TOKEN_JSON_PATH = "$.access_token";
-    private static final String DEFAULT_OATH_SCRIPT_RESOURCE =
-            "/com/sas/unravl/auth/get-oauth-token.unravl";
+    private static final String DEFAULT_OATH_SCRIPT_RESOURCE = "/com/sas/unravl/auth/get-oauth-token.unravl";
     private static final String OAUTH_SCRIPT_KEY = "OAauth2Script";
     private String tokenUrl;
     private static final Logger logger = Logger.getLogger(OAuth2Auth.class);
@@ -75,24 +70,23 @@ public class OAuth2Auth
 
     @Override
     public void authenticate(UnRAVL script, ObjectNode oauthSpec, ApiCall call)
-        throws UnRAVLException
-    {
+            throws UnRAVLException {
         super.authenticate(script, oauthSpec, call);
         authenticateAndAddAuthenticationHeader(oauthSpec);
     }
 
     void authenticateAndAddAuthenticationHeader(ObjectNode auth)
-        throws UnRAVLException
-    {
-        try
-        {
+            throws UnRAVLException {
+        try {
             if (getScript().getURI() == null || getScript().getMethod() == null)
-                throw new UnRAVLException("oauth2 auth requires an HTTP method and URI");
+                throw new UnRAVLException(
+                        "oauth2 auth requires an HTTP method and URI");
             // Note: The URI should already be expanded at this point
             long start = System.currentTimeMillis();
             JsonNode tokenNode = Json.firstFieldValue(getScriptlet());
             if (tokenNode == null || !(tokenNode instanceof TextNode))
-                throw new UnRAVLException("oauth2 auth requires an oauth-server-URL.");
+                throw new UnRAVLException(
+                        "oauth2 auth requires an oauth-server-URL.");
             tokenUrl = getScript().expand(tokenNode.textValue());
             String access_token = getAccessToken(new URI(tokenUrl), auth);
             bindAccessTokenInEnv(auth, access_token);
@@ -100,129 +94,138 @@ public class OAuth2Auth
             long end = System.currentTimeMillis();
             logger.trace("oauth2 authentication took " + (end - start) + "ms");
 
-        }
-        catch (URISyntaxException e)
-        {
+        } catch (URISyntaxException e) {
             new UnRAVLException(e.getMessage(), e);
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             new UnRAVLException(e.getMessage(), e);
         }
 
     }
 
     // bind "access_token" in the environment, or if the oath2 object
-    // contains a "bindAccessToken" : "varName" option, bind to that var name instead.
+    // contains a "bindAccessToken" : "varName" option, bind to that var name
+    // instead.
     // for example for
     // "bindAccessToken" : "bitlyAccessToken"
     // the oauth2 object will bind the variable
     // "bitlyAccessToken" in the environment instead of "access_token"
     private void bindAccessTokenInEnv(ObjectNode auth, String access_token)
-        throws UnRAVLException
-    {
+            throws UnRAVLException {
         // we normally store the token via access_token but the caller
         // can override this with their own variable name to bind
-        String callerKey = stringOption(auth, BIND_ACCESS_TOKEN_KEY, ACCESS_TOKEN);
+        String callerKey = stringOption(auth, BIND_ACCESS_TOKEN_KEY,
+                ACCESS_TOKEN);
         getScript().bind(callerKey, access_token);
         // TODO: this should be added to the ApiCall; this means
-        // we need to add headers field to the ApiCall. Ditto for Basic auth which also adds 
+        // we need to add headers field to the ApiCall. Ditto for Basic auth
+        // which also adds
         // an Authentication header
-        getScript().addRequestHeader(new BasicHeader("Authorization", "Bearer " + access_token));
-        logger.info("\"oauth2\" auth added 'Authorization: Bearer " + access_token + "' header");
+        getScript().addRequestHeader(
+                new BasicHeader("Authorization", "Bearer " + access_token));
+        logger.info("\"oauth2\" auth added 'Authorization: Bearer "
+                + access_token + "' header");
     }
 
-    // Add an access_token={access_token} query parameter to the URI using the parameter name.
-    // Default is to use the name access_token . 
-    // Use "parameter" : "" to change the parameter name. 
+    // Add an access_token={access_token} query parameter to the URI using the
+    // parameter name.
+    // Default is to use the name access_token .
+    // Use "parameter" : "" to change the parameter name.
     // Use "parameter" : "" to suppress it.
     private void addOptionalQueryParameter(ObjectNode auth, String access_token)
-        throws UnRAVLException
-    {
-        // if client specifies a query parameter, we will add it to the request URI
+            throws UnRAVLException {
+        // if client specifies a query parameter, we will add it to the request
+        // URI
         JsonNode p = auth.get(PARAMETER_KEY);
         String queryParm;
-        if (p!= null && p.isBoolean()) {
+        if (p != null && p.isBoolean()) {
             if (p.booleanValue())
                 queryParm = ACCESS_TOKEN;
             else
                 return;
         } else {
-           queryParm = stringOption(auth, PARAMETER_KEY, ACCESS_TOKEN);
+            queryParm = stringOption(auth, PARAMETER_KEY, ACCESS_TOKEN);
         }
-        if (queryParm != null && !"".equals(queryParm))
-        {
+        if (queryParm != null && !"".equals(queryParm)) {
             StringBuilder uri = new StringBuilder(getCall().getURI());
             String delim = (uri.indexOf("?") == -1) ? "?" : "&";
-            uri.append(delim).append(queryParm).append("=").append(access_token);
+            uri.append(delim).append(queryParm).append("=")
+                    .append(access_token);
             getCall().setURI(uri.toString());
-            logger.info("\"oauth2\" auth added '" + delim + queryParm + "=" + access_token
-                    + "' query parameter");
+            logger.info("\"oauth2\" auth added '" + delim + queryParm + "="
+                    + access_token + "' query parameter");
         }
     }
 
     /**
-     * Cache the access_token for this URI's host in the environment, so subsequent oauth objects do
-     * not have to reauthenticate. The access token is stored in the environment as
-     * "{userId}.{hostname}.access_token".
+     * Cache the access_token for this URI's host in the environment, so
+     * subsequent oauth objects do not have to reauthenticate. The access token
+     * is stored in the environment as "{userId}.{hostname}.access_token".
      *
-     * @param userId the user id
-     * @param hostname the hostname of auth server URI
-     * @param accessToken the access_token string
+     * @param userId
+     *            the user id
+     * @param hostname
+     *            the hostname of auth server URI
+     * @param accessToken
+     *            the access_token string
      * @retun the <var>accessToken</var>
      */
-    private String cacheAccessToken(String userId, String hostname, String accessToken)
-    {
+    private String cacheAccessToken(String userId, String hostname,
+            String accessToken) {
         getScript().bind(accessTokenCacheKey(userId, hostname), accessToken);
         return accessToken;
     }
 
-    private String accessTokenCacheKey(String userId, String hostname)
-    {
+    private String accessTokenCacheKey(String userId, String hostname) {
         return userId + "." + hostname + "." + ACCESS_TOKEN;
     }
 
     /**
-     * Get the access token. If it is part of the credentials for the OAuth2 host, return that
-     * static access token.
+     * Get the access token. If it is part of the credentials for the OAuth2
+     * host, return that static access token.
      * <p>
      * If a cached token exists, return it.
      * </p>
      * <p>
-     * Otherwise, use UnRAVL to run an REST API POST call to the authentication server to get an
-     * OAAth access token. The default call uses Basic Authentication using with the clientId and
-     * clientSecret to authenticate. The default request body is a
+     * Otherwise, use UnRAVL to run an REST API POST call to the authentication
+     * server to get an OAAth access token. The default call uses Basic
+     * Authentication using with the clientId and clientSecret to authenticate.
+     * The default request body is a
      * <code>application/x-www-form-urlencoded</code> form
      * </p>
      * 
      * <pre>
      *  { "grant_type" : "password",
-          "username" : "{userId}",
-          "password" : "{password}" }
+     *           "username" : "{userId}",
+     *           "password" : "{password}" }
      * </pre>
      * <p>
-     * where <code>userId</code> and <code>password</code> are the user id and password associated
-     * with the OAth authentication server hostname. The client ID, client password, user ID and
-     * password are read from the {@link CredentialsProvider}, normally the
-     * {@link NetrcCredentialsProvider}. See that class for the format of the <code>.netrc</code>
-     * file.
+     * where <code>userId</code> and <code>password</code> are the user id and
+     * password associated with the OAth authentication server hostname. The
+     * client ID, client password, user ID and password are read from the
+     * {@link CredentialsProvider}, normally the
+     * {@link NetrcCredentialsProvider}. See that class for the format of the
+     * <code>.netrc</code> file.
      * <p>
      * The UnRAVL script is found via the classpath at
-     * <code>/com/sas/unravl/auth/get-oauth-token.unravl</code> (the default resource is in the
-     * UnRAVL jar) but this resource path can be changed by the text option
-     * <code>"OAauth2Script" : "/paths/to/unravl/script"</code> in the <code>"oath2"</code> element.
-     * The UnRAVL script should invoke the POST to the authentication server, then extract and bind
-     * the variable <code>access_token</code> from the response.
+     * <code>/com/sas/unravl/auth/get-oauth-token.unravl</code> (the default
+     * resource is in the UnRAVL jar) but this resource path can be changed by
+     * the text option <code>"OAauth2Script" : "/paths/to/unravl/script"</code>
+     * in the <code>"oath2"</code> element. The UnRAVL script should invoke the
+     * POST to the authentication server, then extract and bind the variable
+     * <code>access_token</code> from the response.
      * </p>
      * 
-     * @param authTokenURI URI of the authorization token server
-     * @param creds credentials associated with the token server
+     * @param authTokenURI
+     *            URI of the authorization token server
+     * @param creds
+     *            credentials associated with the token server
      * @return the <code>access_token</code> for the client/user
-     * @throws UnRAVLException if the script execution encounters an error
+     * @throws UnRAVLException
+     *             if the script execution encounters an error
      */
     private String getAccessToken(URI authTokenURI, ObjectNode auth)
-        throws UnRAVLException, URISyntaxException, ClientProtocolException, IOException
-    {
+            throws UnRAVLException, URISyntaxException,
+            ClientProtocolException, IOException {
 
         String host = authTokenURI.getHost();
         String access_token = null;
@@ -233,31 +236,31 @@ public class OAuth2Auth
         cp.setRuntime(runtime);
         HostCredentials credentials = cp.getHostCredentials(host, auth, false);
         if (credentials == null)
-            throw new UnRAVLAssertionException("No auth credentials for host " + host);
-        if (!(credentials instanceof OAuth2Credentials))
-            throw new UnRAVLAssertionException("Authentication credentials for host lack clientid and secret"
+            throw new UnRAVLAssertionException("No auth credentials for host "
                     + host);
-        OAuth2Credentials creds = (OAuth2Credentials)credentials;
+        if (!(credentials instanceof OAuth2Credentials))
+            throw new UnRAVLAssertionException(
+                    "Authentication credentials for host lack clientid and secret"
+                            + host);
+        OAuth2Credentials creds = (OAuth2Credentials) credentials;
         String user = creds.getUserName();
-        if (creds.getAccessToken() != null)
-        {
+        if (creds.getAccessToken() != null) {
             access_token = creds.getAccessToken();
             return cacheAccessToken(user, host, access_token);
         }
 
         String key = accessTokenCacheKey(user, host);
-        if (runtime.bound(key))
-        {
-            access_token = (String)getScript().getRuntime().binding(key);
-            logger.info(String.format("Found cached OAuth2 access_token for user %s and host %s",
-                                      user, host));
+        if (runtime.bound(key)) {
+            access_token = (String) getScript().getRuntime().binding(key);
+            logger.info(String.format(
+                    "Found cached OAuth2 access_token for user %s and host %s",
+                    user, host));
             return cacheAccessToken(user, host, access_token);
         }
 
         // See if the access token is cached for this user/host
-        if (runtime.bound(key))
-        {
-            access_token = (String)getCall().getVariable(key);
+        if (runtime.bound(key)) {
+            access_token = (String) getCall().getVariable(key);
             logger.info("Using cached oauth2 access token: " + access_token);
             return cacheAccessToken(user, host, access_token);
         }
@@ -265,10 +268,10 @@ public class OAuth2Auth
         // Else, use UnRAVL to send a request to the server to generate an
         // access_token
 
-        String oAuthScriptResourcePath =
-                stringOption(getScriptlet(), OAUTH_SCRIPT_KEY, DEFAULT_OATH_SCRIPT_RESOURCE);
-        String accessTokenJsonPath = stringOption(auth, ACCESS_TOKEN_JSON_PATH_KEY,
-                                                  DEFAULT_ACCESS_TOKEN_JSON_PATH);
+        String oAuthScriptResourcePath = stringOption(getScriptlet(),
+                OAUTH_SCRIPT_KEY, DEFAULT_OATH_SCRIPT_RESOURCE);
+        String accessTokenJsonPath = stringOption(auth,
+                ACCESS_TOKEN_JSON_PATH_KEY, DEFAULT_ACCESS_TOKEN_JSON_PATH);
 
         // We need a new runtime because we don't want this script to
         // be recorded in the calling runtime's history of scripts, or these
@@ -278,60 +281,51 @@ public class OAuth2Auth
         tokenRuntime.bind(ACCESS_TOKEN_JSON_PATH_KEY, accessTokenJsonPath);
 
         // @formatter:off
-        tokenRuntime // Hmmmm, is it worth defining constants for these keys?
-        .bind("oath2TokenUrl", authTokenURI.toString())
-        .bind("clientId",      creds.getClientId())
-        .bind("clientSecret",  creds.getClientSecret())
-        .bind("userId",        creds.getUserName())
-        .bind("password",       creds.getPassword())
-        .bind(ACCESS_TOKEN_JSON_PATH_KEY, accessTokenJsonPath);
-        //@formatter:on
+        tokenRuntime
+                // Hmmmm, is it worth defining constants for these keys?
+                .bind("oath2TokenUrl", authTokenURI.toString())
+                .bind("clientId", creds.getClientId())
+                .bind("clientSecret", creds.getClientSecret())
+                .bind("userId", creds.getUserName())
+                .bind("password", creds.getPassword())
+                .bind(ACCESS_TOKEN_JSON_PATH_KEY, accessTokenJsonPath);
+        // @formatter:on
         ObjectMapper mapper = new ObjectMapper();
-        try (InputStream in = openScriptStream(oAuthScriptResourcePath))
-        {
-            ObjectNode accessAuthJson = (ObjectNode)mapper.readTree(in);
-            UnRAVL oathAccessTokenScript = new UnRAVL(tokenRuntime, accessAuthJson);
+        try (InputStream in = openScriptStream(oAuthScriptResourcePath)) {
+            ObjectNode accessAuthJson = (ObjectNode) mapper.readTree(in);
+            UnRAVL oathAccessTokenScript = new UnRAVL(tokenRuntime,
+                    accessAuthJson);
             oathAccessTokenScript.run();
-            access_token = (String)tokenRuntime.binding(ACCESS_TOKEN);
-        }
-        catch (IOException e)
-        {
+            access_token = (String) tokenRuntime.binding(ACCESS_TOKEN);
+        } catch (IOException e) {
             throw new UnRAVLException(e.getMessage(), e);
         }
         return cacheAccessToken(user, host, access_token);
     }
 
-    private InputStream openScriptStream(String path)
-        throws UnRAVLException
-    {
-        if (path.startsWith("@"))
-        {
+    private InputStream openScriptStream(String path) throws UnRAVLException {
+        if (path.startsWith("@")) {
             String urlPath = path.substring(1);
-            try
-            {
+            try {
                 return new URL(urlPath).openStream();
-            }
-            catch (IOException e)
-            {
-                throw new UnRAVLException("Cannot access oath2 " + OAUTH_SCRIPT_KEY + " '" + path
-                        + "' as a URL", e);
+            } catch (IOException e) {
+                throw new UnRAVLException("Cannot access oath2 "
+                        + OAUTH_SCRIPT_KEY + " '" + path + "' as a URL", e);
             }
         }
-        // Not a @url; try to load relative to the classpath, or if that fails, as a file.
+        // Not a @url; try to load relative to the classpath, or if that fails,
+        // as a file.
         InputStream is = getClass().getResourceAsStream(path);
         if (is != null)
             return is;
-        else
-        {
-            try
-            {
+        else {
+            try {
                 File file = new File(path);
                 is = new FileInputStream(file);
                 return is;
-            }
-            catch (IOException e)
-            {
-                throw new UnRAVLException("Cannot open oath2 " + OAUTH_SCRIPT_KEY + " '" + path
+            } catch (IOException e) {
+                throw new UnRAVLException("Cannot open oath2 "
+                        + OAUTH_SCRIPT_KEY + " '" + path
                         + "' as via classpath or as a file");
             }
         }

--- a/src/main/java/com/sas/unravl/auth/OAuth2Credentials.java
+++ b/src/main/java/com/sas/unravl/auth/OAuth2Credentials.java
@@ -2,18 +2,18 @@
 package com.sas.unravl.auth;
 
 /**
- * A holder class for credentials for OAuth2 authentication,
- * using a user id, password, clientId, clientSecret, and accessToken
- * in addition to user and password managed by the base {@link HostCredentials} class.
- * For security,
- * one should not retain this object for a long period of time; use the clear()
+ * A holder class for credentials for OAuth2 authentication, using a user id,
+ * password, clientId, clientSecret, and accessToken in addition to user and
+ * password managed by the base {@link HostCredentials} class. For security, one
+ * should not retain this object for a long period of time; use the clear()
  * method so the password is not retained.
+ * 
  * @author David.Biesack@sas.com
  */
 public class OAuth2Credentials extends HostCredentials {
 
     private String clientId, clientSecret, accessToken;
-    
+
     public String getClientId() {
         return clientId;
     }
@@ -26,12 +26,13 @@ public class OAuth2Credentials extends HostCredentials {
         return accessToken;
     }
 
-    public OAuth2Credentials(String userName, String password, String clientId, String clientSecret, String accessToken) {
+    public OAuth2Credentials(String userName, String password, String clientId,
+            String clientSecret, String accessToken) {
         super(userName, password);
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.accessToken = accessToken;
-    }    
+    }
 
     public void clear() {
         super.clear();

--- a/src/main/java/com/sas/unravl/extractors/LinksExtractor.java
+++ b/src/main/java/com/sas/unravl/extractors/LinksExtractor.java
@@ -122,13 +122,14 @@ import org.apache.log4j.Logger;
  * Note that "link" may be used instead of "links"; this is clearer for
  * extracting a single link.
  * <p>
- * An extra option, <code>"unwrap" : true</code>
- * may be used to unwrap the Jackson <code>ObjectNode</code> values from
- * the links into a <code>java.util.Map</code>. For example:
+ * An extra option, <code>"unwrap" : true</code> may be used to unwrap the
+ * Jackson <code>ObjectNode</code> values from the links into a
+ * <code>java.util.Map</code>. For example:
  * 
  * <pre>
  *  { "link" : { "self" : "self" }, "unwrap" : true }
  * </pre>
+ * 
  * <h3>Extracting just the href value from links</h3>
  * <p>
  * If the extractor is used with the key "hrefs" or "href" instead of "links",
@@ -432,7 +433,7 @@ public class LinksExtractor extends BaseUnRAVLExtractor {
                         String.format(
                                 "responseBody is not bound to a JSON object in %s extractor: %s",
                                 key(root), f));
-            } 
+            }
         } else {
             if (fromNode.isTextual()) {
                 String where = fromNode.textValue();

--- a/src/main/java/com/sas/unravl/generators/FormBodyGenerator.java
+++ b/src/main/java/com/sas/unravl/generators/FormBodyGenerator.java
@@ -105,8 +105,8 @@ public class FormBodyGenerator extends BaseUnRAVLRequestBodyGenerator {
         }
         String bodyText = body.toString();
         script.bind("requestBody", bodyText);
-        script.addRequestHeader(
-                new BasicHeader("Content-Type", "application/x-www-form-urlencoded"));
+        script.addRequestHeader(new BasicHeader("Content-Type",
+                "application/x-www-form-urlencoded"));
         return new ByteArrayInputStream(Text.utf8(bodyText));
     }
 
@@ -117,8 +117,11 @@ public class FormBodyGenerator extends BaseUnRAVLRequestBodyGenerator {
         try {
             String delim = "";
             for (Entry<String, JsonNode> x : Json.fields(inputJson)) {
-                body.append(delim).append(x.getKey()).append("=")
-                        .append(URLEncoder.encode(x.getValue().asText(), "UTF-8"));
+                body.append(delim)
+                        .append(x.getKey())
+                        .append("=")
+                        .append(URLEncoder.encode(x.getValue().asText(),
+                                "UTF-8"));
                 delim = "&";
             }
         } catch (UnsupportedEncodingException e) {

--- a/src/main/java/com/sas/unravl/generators/FormBodyGenerator.java
+++ b/src/main/java/com/sas/unravl/generators/FormBodyGenerator.java
@@ -21,12 +21,12 @@ import org.apache.log4j.Logger;
 /**
  * Generates a <code>application/x-www-form-urlencoded</code> request body for
  * this API call. The node can have one of several forms:
- * 
+ *
  * <pre>
  * { "form" : json-object }
  * { "form" : "@file-or-url" }
  * { "form" : "varName" }
- * { "form" : "name=encoded-&name=encoded-value&name=encoded-value" }
+ * { "form" : "name=encoded-&amp;name=encoded-value&amp;name=encoded-value" }
  * </pre>
  * <p>
  * In the first form the request body is derived from a JSON object. Each value
@@ -55,9 +55,9 @@ import org.apache.log4j.Logger;
  * The form body is bound in the current environment as a string named
  * "requestBody".
  * <p>
- * 
+ *
  * @author David.Biesack@sas.com
- * 
+ *
  */
 @UnRAVLRequestBodyGeneratorPlugin("form")
 public class FormBodyGenerator extends BaseUnRAVLRequestBodyGenerator {

--- a/src/main/java/com/sas/unravl/util/Json.java
+++ b/src/main/java/com/sas/unravl/util/Json.java
@@ -106,7 +106,8 @@ public class Json {
                     ObjectNode from = (ObjectNode) node;
                     ObjectNode to = new ObjectNode(jnf);
                     for (Map.Entry<String, JsonNode> f : Json.fields(from)) {
-                        to.set(script.expand(f.getKey()), this.apply(f.getValue()));
+                        to.set(script.expand(f.getKey()),
+                                this.apply(f.getValue()));
                     }
                     return to;
                 } else
@@ -388,7 +389,6 @@ public class Json {
     public static ObjectNode wrap(@SuppressWarnings("rawtypes") Map val) {
         return mapper.valueToTree(val);
     }
-
 
     // Convert a Java List to a JSON ArrayNode
     public static ObjectNode wrap(@SuppressWarnings("rawtypes") List val) {

--- a/src/test/java/com/sas/unrav/auth/test/TestNetrcCredentials.java
+++ b/src/test/java/com/sas/unrav/auth/test/TestNetrcCredentials.java
@@ -29,17 +29,23 @@ public class TestNetrcCredentials {
 
     @Parameters(name = "{index} host {0}, expect user {1}, password {2}")
     public static Collection<Object[]> testCases() {
-        
-        return Arrays.asList(new Object[][] { //@formatter:off
-                // this test data should match src/test/netrc/.netrc
-                new String[] {"simple.host.com","test.user.a", "test.user.a-secret", null, null},
-                new String[] {"host.withport8080.com:8080", "test.user.b", "test.user.b-secret", null, null},
-                new String[] {"host.whitespace.com", "test.user.c", "test.user.c-secret", null, null},
-                new String[] {"host.special.com", "test.user.d", "test.user.d password", null, null},
-                new String[] {"host.alt.order", "test.user.e", "test.password.e", null, null},
-                new String[] {"auth.server1", "OAuthUser-1", "OAuth2 password 1", "0x0123456789abcdef", "0xgfedcba9876543210" }
-                });
-    } //@formatter:on
+
+        return Arrays.asList(new Object[][] { // @formatter:off
+                        // this test data should match src/test/netrc/.netrc
+                        new String[] { "simple.host.com", "test.user.a",
+                                "test.user.a-secret", null, null },
+                        new String[] { "host.withport8080.com:8080",
+                                "test.user.b", "test.user.b-secret", null, null },
+                        new String[] { "host.whitespace.com", "test.user.c",
+                                "test.user.c-secret", null, null },
+                        new String[] { "host.special.com", "test.user.d",
+                                "test.user.d password", null, null },
+                        new String[] { "host.alt.order", "test.user.e",
+                                "test.password.e", null, null },
+                        new String[] { "auth.server1", "OAuthUser-1",
+                                "OAuth2 password 1", "0x0123456789abcdef",
+                                "0xgfedcba9876543210" } });
+    } // @formatter:on
 
     static String userHome = null;
 
@@ -63,8 +69,9 @@ public class TestNetrcCredentials {
     String expectedClientId;
     String expectedClientSecret;
 
-    public TestNetrcCredentials(String hostName, String expectedUserName, String expectedPassword, String expectedClientId,
-    String expectedClientSecret) {
+    public TestNetrcCredentials(String hostName, String expectedUserName,
+            String expectedPassword, String expectedClientId,
+            String expectedClientSecret) {
         this.hostName = hostName;
         this.expectedUserName = expectedUserName;
         this.expectedPassword = expectedPassword;
@@ -84,8 +91,7 @@ public class TestNetrcCredentials {
         nc.setRuntime(rt);
 
         ObjectNode node = (ObjectNode) Json.parse("{ \"basic\" : true }");
-        HostCredentials cred = nc.getHostCredentials(hostName, node,
-                false);
+        HostCredentials cred = nc.getHostCredentials(hostName, node, false);
         assertEquals(expectedUserName, cred.getUserName());
         assertEquals(expectedPassword, cred.getPassword());
         if (cred instanceof OAuth2Credentials) {

--- a/src/test/java/com/sas/unravl/test/TestExpand.java
+++ b/src/test/java/com/sas/unravl/test/TestExpand.java
@@ -31,19 +31,32 @@ public class TestExpand extends TestBase {
     public void testMap() throws UnRAVLException {
         UnRAVL script = TestBase.scriptFixture();
         String in = "{ 's' : 'string', 'b' : true, 'i' : 123, 'd': 3.14159, "
-                + " '{unboundVar|a}' : [ '{" + TIME_KEY + "}', 'is the time for {" + WHICH_KEY + "}', '{" + WHO_KEY + "} to come to the aid', 'of their {" + WHERE_KEY + "}' ],"
-                + " '{" + WHERE_KEY + "}' : { 'x' : '{" + WHICH_KEY + "} {" + WHERE_KEY + "}s' } }";
+                + " '{unboundVar|a}' : [ '{" + TIME_KEY
+                + "}', 'is the time for {" + WHICH_KEY + "}', '{" + WHO_KEY
+                + "} to come to the aid', 'of their {" + WHERE_KEY + "}' ],"
+                + " '{" + WHERE_KEY + "}' : { 'x' : '{" + WHICH_KEY + "} {"
+                + WHERE_KEY + "}s' } }";
 
         String outExpected = "{ 's' : 'string', 'b' : true, 'i' : 123, 'd': 3.14159, "
-                + " 'a' : [ '" + TIME_VAL + "', 'is the time for " + WHICH_VAL + "', '" + WHO_VAL + " to come to the aid', 'of their " + WHERE_VAL + "' ],"
-                + " '" + WHERE_VAL + "' : { 'x' : '" + WHICH_VAL + " " + WHERE_VAL + "s' } }";
+                + " 'a' : [ '"
+                + TIME_VAL
+                + "', 'is the time for "
+                + WHICH_VAL
+                + "', '"
+                + WHO_VAL
+                + " to come to the aid', 'of their "
+                + WHERE_VAL
+                + "' ],"
+                + " '"
+                + WHERE_VAL
+                + "' : { 'x' : '"
+                + WHICH_VAL + " " + WHERE_VAL + "s' } }";
         JsonNode actual = Json.expand(TestBase.mockJson(in), script);
         System.out.println(actual);
         JsonNode expected = TestBase.mockJson(outExpected);
         assertEquals(expected, actual);
     }
 
-    
     // No conditional assignment for 'env' binding
     @Test
     public void testNoConditionalAssignmentForEnvBinding()

--- a/src/test/java/com/sas/unravl/test/TestJsonPath.java
+++ b/src/test/java/com/sas/unravl/test/TestJsonPath.java
@@ -33,7 +33,8 @@ public class TestJsonPath {
         Object jo;
         if (node instanceof ObjectNode)
             jo = m.convertValue(node, Map.class);
-        else // (node instanceof ArrayNode)
+        else
+            // (node instanceof ArrayNode)
             jo = m.convertValue(node, List.class);
         // JsonPath parses strings into java.util.Map and java.util.List
         // objects.
@@ -53,7 +54,7 @@ public class TestJsonPath {
         ArrayNode an = m.valueToTree(a);
         assertNotNull(on);
         assertNotNull(an);
-        assertEquals(2,on.size());
+        assertEquals(2, on.size());
         assertEquals(6, an.size());
     }
 }

--- a/src/test/java/com/sas/unravl/test/TestScriptsWithMockServer.java
+++ b/src/test/java/com/sas/unravl/test/TestScriptsWithMockServer.java
@@ -28,7 +28,8 @@ import org.springframework.web.client.RestTemplate;
 public class TestScriptsWithMockServer extends TestBase {
 
     private static final String SRC_TEST_SCRIPTS_MOCK = "src/test/scripts/mock";
-    private static final String SRC_TEST_SCRIPTS_MOCK_FAIL = SRC_TEST_SCRIPTS_MOCK + "/fail";
+    private static final String SRC_TEST_SCRIPTS_MOCK_FAIL = SRC_TEST_SCRIPTS_MOCK
+            + "/fail";
     private RestTemplate restTemplate;
     private MockRestServiceServer mockServer;
 
@@ -60,7 +61,6 @@ public class TestScriptsWithMockServer extends TestBase {
                 "helloJson.json");
         mockServer.verify();
     }
-
 
     @Test
     public void helloJsonFail() throws UnRAVLException {
@@ -95,7 +95,6 @@ public class TestScriptsWithMockServer extends TestBase {
         JUnitWrapper.tryScriptsInDirectory(runtime, null,
                 SRC_TEST_SCRIPTS_MOCK_FAIL, "helloText.json");
     }
-
 
     private void createHelloTextMock() {
         mockServer.expect(requestTo("/hello.txt")).andRespond(

--- a/src/test/java/com/sas/unravl/test/TestSimplifyJsonBody.java
+++ b/src/test/java/com/sas/unravl/test/TestSimplifyJsonBody.java
@@ -30,8 +30,7 @@ public class TestSimplifyJsonBody extends TestBase {
 
     @Test
     public void testObjectWithoutJsonKey() throws Exception {
-        assertRequestBodyJson("{'name':'value'}",
-                "{'body':{'name':'value'}}");
+        assertRequestBodyJson("{'name':'value'}", "{'body':{'name':'value'}}");
 
     }
 
@@ -241,7 +240,8 @@ public class TestSimplifyJsonBody extends TestBase {
 
     private String getRequestBodyContent(ApiCall apiCall)
             throws UnRAVLException {
-        apiCall.run(); // These calls may not have a method (PUT or POST) that will consume the requestStream
+        apiCall.run(); // These calls may not have a method (PUT or POST) that
+                       // will consume the requestStream
         if (apiCall.getRequestStream() == null) {
             return null;
         }
@@ -252,7 +252,8 @@ public class TestSimplifyJsonBody extends TestBase {
             requestBodyString = baos.toString("UTF-8");
             return requestBodyString;
         } catch (UnsupportedEncodingException e) {
-            throw new UnRAVLException(e.getMessage());// should not happen; UTF-8 should exist
+            throw new UnRAVLException(e.getMessage());// should not happen;
+                                                      // UTF-8 should exist
         } catch (IOException e) {
             throw new UnRAVLException(e.getMessage());
         }


### PR DESCRIPTION
Version 1.1.0
  * Added [OAuth2](doc/Authentication.md#uath2) authentication
  * A script can disable inherited authentication
  * UnRAVL variables are now expanded in JSON object keys, not just in
    string values
  * Added a [`"form"`](doc/Body.md#form) body generator
  * Expand UnRAVL variables in `"basic"` authentication parameters
  * UnRAVL now follows 3xx redirects for HEAD calls as well as GET calls
  * Added an `"unwrap"` option for the [`"json"`](doc/Bind.md#json)
    response extractor and the [`"links"` and `"hrefs"`](doc/Bind.md#links-and-hrefs )
    extractors
  * Added the[`"jsonPath"`](doc/Bind.md#jsonPath) body extractor
  * Various bug fixes
