### PR TITLE
Add "wrap" : true option to "jsonPath" extractor

### DIFF
--- a/doc/Bind.md
+++ b/doc/Bind.md
@@ -106,7 +106,8 @@ Binds values from the JSON response by extracting data via their
 
 ```
  { "jsonPath" : { map-of-var-path-pairs } }
- { "jsonPath" : { map-of-var-path-pairs }, "from" : "varname" }
+ { "jsonPath" : { map-of-var-path-pairs }, "from" : "varName" }
+ { "jsonPath" : { map-of-var-path-pairs }, "unwrap" : "true" }
 ```
 
 The first form binds from the JSON response.
@@ -120,6 +121,17 @@ The value of that variable should be a JSON object
 (such as from an `"env"` element or a previous
 `"json"` or other extractor) or a `Map<String,Object>`
 or `List<Object>`.
+
+The `"wrap"` option may be used with either form.
+By default, the `"jsonPath"` extractor will
+return Java `Map` or `List` objects.
+Use `"wrap" : true` to wrap the results of the JSON Path
+expression as Jackson `JsonNode` objects. A `Map`
+will be wrapped as a `ObjectNode`; a `List` will
+be wrapped as an `ArrayNode`, and scalar values
+wrapped as `DoubleNode`, `IntegerNode`, `TextNode`, `BooleanNode`,
+`NullNode`, according to the type of the item result
+of the JSON Path.
 
 ```JSON
 { "jsonPath" : {

--- a/src/main/java/com/sas/unravl/BaseUnRAVLPlugin.java
+++ b/src/main/java/com/sas/unravl/BaseUnRAVLPlugin.java
@@ -25,7 +25,7 @@ public abstract class BaseUnRAVLPlugin implements UnRAVLPlugin {
      *            the element inside an UnRAVL script
      * @param optionName
      *            the name of the option
-     * @return true if th eoption was found and has the value true; otherwise
+     * @return true if the option was found and has the value true; otherwise
      *         false
      * @throws UnRAVLException
      *             if the value is not a boolean

--- a/src/main/java/com/sas/unravl/UnRAVLRuntime.java
+++ b/src/main/java/com/sas/unravl/UnRAVLRuntime.java
@@ -379,7 +379,9 @@ public class UnRAVLRuntime implements Cloneable {
             throw new RuntimeException(ue);
         }
         env.put(varName, value);
-        logger.trace("bind(" + varName + "," + value + ")");
+        logger.trace("bind(" + varName + "," + value + ")"
+        + ((value instanceof String) ? "" : 
+            " " + value.getClass().getName()));
         return this;
     }
 

--- a/src/main/java/com/sas/unravl/UnRAVLRuntime.java
+++ b/src/main/java/com/sas/unravl/UnRAVLRuntime.java
@@ -381,7 +381,7 @@ public class UnRAVLRuntime implements Cloneable {
         env.put(varName, value);
         logger.trace("bind(" + varName + "," + value + ")"
         + ((value instanceof String) ? "" : 
-            " " + value.getClass().getName()));
+            " " + (value == null ? "null" : value.getClass().getName())));
         return this;
     }
 

--- a/src/main/java/com/sas/unravl/extractors/JsonPathExtractor.java
+++ b/src/main/java/com/sas/unravl/extractors/JsonPathExtractor.java
@@ -81,6 +81,10 @@ public class JsonPathExtractor extends JsonExtractor {
             throws UnRAVLException {
         Object fromObject = getJsonSource(script, scriptlet, call);
         ObjectNode bindings = Json.object(Json.firstFieldValue(scriptlet));
+        // TODO: look for the effective binding
+        // "bind" : [ ..., { "jsonNode" : {}, "wrap" : true }, ...] 
+        // in inherited templates (match only if the value is {}). If true, wrap this one as well.
+        boolean wrap = booleanOption(scriptlet, "wrap");
         for (Map.Entry<String, JsonNode> entry : Json.fields(bindings)) {
             JsonNode path = entry.getValue();
             if (!path.isTextual()) {
@@ -90,6 +94,9 @@ public class JsonPathExtractor extends JsonExtractor {
             }
             String pathString = call.getScript().expand(path.textValue());
             Object value = JsonPath.read(fromObject, pathString);
+            if (wrap) {
+               value = Json.wrap(value);
+            }
             script.bind(entry.getKey(), value);
         }
     }

--- a/src/main/java/com/sas/unravl/util/Json.java
+++ b/src/main/java/com/sas/unravl/util/Json.java
@@ -385,13 +385,47 @@ public class Json {
         return result;
     }
 
-    // Convert a Java Map to a JSON ObjectNode
+    /** 
+     * Convert a Java Map to a JSON ObjectNode
+     *
+     * @param val a Map object
+     * @return a ObjectNode that corresponds to the Map
+     */
     public static ObjectNode wrap(@SuppressWarnings("rawtypes") Map val) {
         return mapper.valueToTree(val);
     }
 
-    // Convert a Java List to a JSON ArrayNode
-    public static ObjectNode wrap(@SuppressWarnings("rawtypes") List val) {
+    /** 
+     * Convert a Java List to a JSON ArrayNode
+     *
+     * @param val a List object
+     * @return a ArrayNode that corresponds to the Map
+     */
+    public static ArrayNode wrap(@SuppressWarnings("rawtypes") List val) {
         return mapper.valueToTree(val);
     }
+
+    /** 
+     * Convert a Java object to a JsonNode
+     *
+     * @param val a List, Map, or other object
+     * @return a JsonNode that corresponds to the val
+     */
+    @SuppressWarnings("rawtypes")
+    public static JsonNode wrap(Object val) {
+        if (val == null)
+            return NullNode.getInstance();
+        else if (val instanceof Map)
+            return wrap((Map) val);
+        else if (val instanceof List)
+            return wrap((List) val);
+        else {
+            ArrayList<Object> o = new ArrayList<Object>(1);
+            o.add(val);
+            ArrayNode a = wrap(o);
+            JsonNode n = a.get(0);
+            return n;
+        }
+    }
+
 }

--- a/src/test/scripts/jsonPath.json
+++ b/src/test/scripts/jsonPath.json
@@ -45,5 +45,40 @@
           "lat > 27.988 && lat < 27.989",
           "lng > 86.925 && lng < 89.926"
       ]
+  },
+  
+  { "name" : "Extract JsonPath content from a JSON object, but wrapped as Jackson",
+    "env" : { "everest" :
+                {
+                    "results" : [
+                        {
+                            "elevation" : 8815.7158203125,
+                            "location" : {
+                                "lat" : 27.988056,
+                                "lng" : 86.92527800000001
+                            },
+                            "resolution" : 152.7032318115234
+                        }
+                    ],
+                    "status" : "OK"
+                }
+              },
+
+ "bind" : { "jsonPath" : { "results" : "$.results",
+                           "location" : "$.results[0].location",
+                           "lat" : "$.results[0].location.lat",
+                           "lng" : "$.results[0].location.lng" },
+                         "from" : "everest",
+                         "wrap" : true },
+
+  "assert" : [
+          "elevation >= 8815.715 && elevation < 8815.716",
+          "lat.doubleValue() > 27.988 && lat.doubleValue() < 27.989",
+          "lng.doubleValue() > 86.925 && lng.doubleValue() < 89.926",
+          "results instanceof com.fasterxml.jackson.databind.node.ArrayNode",
+          "location instanceof com.fasterxml.jackson.databind.node.ObjectNode",
+          "lat instanceof com.fasterxml.jackson.databind.node.DoubleNode",
+          "lng instanceof com.fasterxml.jackson.databind.node.DoubleNode"
+      ]
   }
 ]


### PR DESCRIPTION
We need a way to convert `"jsonPath"` bind results to Jackson JsonNode objects, for easier comparison with other JSON values assigned via `"env"` or other constructs which create JSON values.