### PR TITLE
Capture response body even on 4xx HTTP response

### DIFF
--- a/src/main/java/com/sas/unravl/ApiCall.java
+++ b/src/main/java/com/sas/unravl/ApiCall.java
@@ -492,6 +492,7 @@ public class ApiCall {
             @Override
             public InternalResponse extractData(ClientHttpResponse response)
                     throws IOException {
+                httpStatus = response.getStatusCode().value();
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 Binary.copy(response.getBody(), baos);
                 return new InternalResponse(response.getStatusCode(),
@@ -511,7 +512,6 @@ public class ApiCall {
                     HttpMethod.valueOf(method.name()), requestCallback,
                     responseExtractor);
             setResponseHeaders(mapHeaders(response.headers));
-            httpStatus = response.status.value();
             responseBody.write(response.responseBody);
             responseBody.close();
             long end = System.currentTimeMillis();
@@ -533,12 +533,12 @@ public class ApiCall {
         } catch (ResourceAccessException e) {
             // execute can also throw ResourceAccessException if host does not
             // resolve.
-            assertStatus(HttpStatus.NOT_FOUND.value());
+            assertStatus(httpStatus);
         } catch (RestClientException e) {
             // execute can also throw RestClientException
             // but that exception does not convey a HTTP status code.
             // We assume 400 if we get RestClientException
-            assertStatus(HttpStatus.BAD_REQUEST.value());
+            assertStatus(httpStatus);
         } catch (RuntimeException e) { // Spring RestTemplate can
                                        // throw NestedRuntimeException
             throwException(e);

--- a/src/main/java/com/sas/unravl/ApiCall.java
+++ b/src/main/java/com/sas/unravl/ApiCall.java
@@ -43,7 +43,6 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RequestCallback;
 import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.ResponseExtractor;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -508,9 +507,9 @@ public class ApiCall {
             // so that even on exceptions, we have a non-null response
             responseBody = new ByteArrayOutputStream();
             httpStatus = HttpStatus.NOT_IMPLEMENTED.value();
-            InternalResponse response = restTemplate.execute(
-                    getURI(), HttpMethod.valueOf(method.name()),
-                    requestCallback, responseExtractor);
+            InternalResponse response = restTemplate.execute(getURI(),
+                    HttpMethod.valueOf(method.name()), requestCallback,
+                    responseExtractor);
             setResponseHeaders(mapHeaders(response.headers));
             httpStatus = response.status.value();
             responseBody.write(response.responseBody);
@@ -520,7 +519,7 @@ public class ApiCall {
                     + "ms, returned HTTP status " + response.status);
             log("Response body:", responseBody, "Response headers:",
                     response.headers);
-            assertStatus(response.status.value());
+            assertStatus(httpStatus);
         } catch (IOException e) {
             throwException(e);
         } catch (HttpStatusCodeException e) {

--- a/src/main/java/com/sas/unravl/UnRAVLPlugins.java
+++ b/src/main/java/com/sas/unravl/UnRAVLPlugins.java
@@ -13,7 +13,6 @@ import com.sas.unravl.extractors.UnRAVLExtractor;
 import com.sas.unravl.generators.UnRAVLRequestBodyGenerator;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,10 +20,15 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
 
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
@@ -192,16 +196,23 @@ public class UnRAVLPlugins {
     }
 
     /**
-     * This RestTemplate uses a custom ClientHttpRequestFactory that follows
-     * redirect for HEAD calls. The default SimpleClientHttpRequestFactory only
-     * follows redirects for GET. see
-     * <a href='http://stackoverflow.com/questions/29418583/follow-302-redirect-using-spring-resttemplate'>
-     * this StackOverflow question</a>.
+     * This RestTemplate uses HttpComponentsClientHttpRequestFactory that
+     * follows redirect for GET and HEAD calls. We use
+     * HttpComponentsClientHttpRequestFactory because the default
+     * HttpUrlConnection used by Spring throws I/O exceptions from
+     * response.getBody() when the remote call returns 4xx responses, which
+     * means the client can't read the response body that accompanies such
+     * errors. The Apache HTTP Commons implementation of HttpUrlConnection does
+     * not throw such exceptions, so UnRAVL can read the response body in all
+     * cases.
      * <p>
      * This instance also sets an error handler which ignores all errors, so
      * that ApiCall can extract the HTTP response code, headers, and response
      * body.
      * </p>
+     * 
+     * @return a RestTemplate instance to use for making HTTP calls when running
+     *         UnRAVL scripts.
      */
     public static RestTemplate newRestTemplate() {
 
@@ -221,22 +232,23 @@ public class UnRAVLPlugins {
                 return false;
             }
         };
-        RestTemplate rt = new RestTemplate(
-                new SimpleClientHttpRequestFactory() {
-                    @Override
-                    protected void prepareConnection(
-                            HttpURLConnection connection, String httpMethod)
-                            throws IOException {
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        final HttpClient httpClient = HttpClientBuilder.create()
+                .setRedirectStrategy(new UnRAVLRedirectStrategy()).build();
+        factory.setHttpClient(httpClient);
 
-                        super.prepareConnection(connection, httpMethod);
-
-                        if ("HEAD".equals(httpMethod)) {
-                            connection.setInstanceFollowRedirects(true);
-                        }
-                    }
-                });
+        RestTemplate rt = new RestTemplate(factory);
         rt.setErrorHandler(ignoreResponseErrors);
         return rt;
     }
 
+    private static final class UnRAVLRedirectStrategy extends
+            DefaultRedirectStrategy {
+
+        @Override
+        protected boolean isRedirectable(final String method) {
+            return HttpGet.METHOD_NAME.equalsIgnoreCase(method) //
+                    || HttpHead.METHOD_NAME.equalsIgnoreCase(method);
+        }
+    }
 }

--- a/src/main/java/com/sas/unravl/UnRAVLRuntime.java
+++ b/src/main/java/com/sas/unravl/UnRAVLRuntime.java
@@ -379,9 +379,13 @@ public class UnRAVLRuntime implements Cloneable {
             throw new RuntimeException(ue);
         }
         env.put(varName, value);
-        logger.trace("bind(" + varName + "," + value + ")"
-        + ((value instanceof String) ? "" : 
-            " " + (value == null ? "null" : value.getClass().getName())));
+        logger.trace("bind("
+                + varName
+                + ","
+                + value
+                + ")"
+                + ((value instanceof String) ? "" : " "
+                        + (value == null ? "null" : value.getClass().getName())));
         return this;
     }
 

--- a/src/main/java/com/sas/unravl/auth/OAuth2Auth.java
+++ b/src/main/java/com/sas/unravl/auth/OAuth2Auth.java
@@ -46,8 +46,8 @@ import org.apache.log4j.Logger;
  * 
  * <h2>Options</h2> The "oath2" object supports several options to configure the
  * OAUth2 authentication. See <a href=
- * 'https://github.com/sassoftware/unravl/blob/master/doc/Authentication.md#oauth2'
- * > Authentication: oauth2</a> for complete details.
+ * 'https://github.com/sassoftware/unravl/blob/master/doc/Authentication.md#oauth2
+ * ' > Authentication: oauth2</a> for complete details.
  * <p>
  * This auth module may be accessed with either the name <code>"oauth2"</code>,
  * <code>"OAuth2"</code>, <code>"oauth"</code>, <code>"OAuth"</code>.

--- a/src/main/java/com/sas/unravl/extractors/JsonPathExtractor.java
+++ b/src/main/java/com/sas/unravl/extractors/JsonPathExtractor.java
@@ -82,8 +82,9 @@ public class JsonPathExtractor extends JsonExtractor {
         Object fromObject = getJsonSource(script, scriptlet, call);
         ObjectNode bindings = Json.object(Json.firstFieldValue(scriptlet));
         // TODO: look for the effective binding
-        // "bind" : [ ..., { "jsonNode" : {}, "wrap" : true }, ...] 
-        // in inherited templates (match only if the value is {}). If true, wrap this one as well.
+        // "bind" : [ ..., { "jsonNode" : {}, "wrap" : true }, ...]
+        // in inherited templates (match only if the value is {}). If true, wrap
+        // this one as well.
         boolean wrap = booleanOption(scriptlet, "wrap");
         for (Map.Entry<String, JsonNode> entry : Json.fields(bindings)) {
             JsonNode path = entry.getValue();
@@ -95,7 +96,7 @@ public class JsonPathExtractor extends JsonExtractor {
             String pathString = call.getScript().expand(path.textValue());
             Object value = JsonPath.read(fromObject, pathString);
             if (wrap) {
-               value = Json.wrap(value);
+                value = Json.wrap(value);
             }
             script.bind(entry.getKey(), value);
         }

--- a/src/main/java/com/sas/unravl/util/Json.java
+++ b/src/main/java/com/sas/unravl/util/Json.java
@@ -385,30 +385,33 @@ public class Json {
         return result;
     }
 
-    /** 
+    /**
      * Convert a Java Map to a JSON ObjectNode
      *
-     * @param val a Map object
+     * @param val
+     *            a Map object
      * @return a ObjectNode that corresponds to the Map
      */
     public static ObjectNode wrap(@SuppressWarnings("rawtypes") Map val) {
         return mapper.valueToTree(val);
     }
 
-    /** 
+    /**
      * Convert a Java List to a JSON ArrayNode
      *
-     * @param val a List object
+     * @param val
+     *            a List object
      * @return a ArrayNode that corresponds to the Map
      */
     public static ArrayNode wrap(@SuppressWarnings("rawtypes") List val) {
         return mapper.valueToTree(val);
     }
 
-    /** 
+    /**
      * Convert a Java object to a JsonNode
      *
-     * @param val a List, Map, or other object
+     * @param val
+     *            a List, Map, or other object
      * @return a JsonNode that corresponds to the val
      */
     @SuppressWarnings("rawtypes")

--- a/src/test/java/com/sas/unravl/test/TestScriptsWithMockServer.java
+++ b/src/test/java/com/sas/unravl/test/TestScriptsWithMockServer.java
@@ -3,6 +3,7 @@ package com.sas.unravl.test;
 
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.sas.unravl.UnRAVLException;
@@ -13,6 +14,7 @@ import com.sas.unravl.assertions.JUnitWrapper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
@@ -81,17 +83,6 @@ public class TestScriptsWithMockServer extends TestBase {
                                         .toString(), MediaType.APPLICATION_JSON));
     }
 
-
-    private void createErrorJsonMock() throws UnRAVLException {
-        String responseBody = mockJson("{ 'error' : 'BAD REQUEST', 'httpStatusCode' : 400 }").toString();
-        mockServer
-                .expect(requestTo("/error.json"))
-                .andRespond(
-                        withBadRequest().body(responseBody).contentType(MediaType.APPLICATION_JSON));
-    }
-
-
-
     @Test
     public void helloText() throws UnRAVLException {
         createHelloTextMock();
@@ -143,6 +134,34 @@ public class TestScriptsWithMockServer extends TestBase {
                 "errorJson.json");
         mockServer.verify();
     }
+
+    private void createErrorJsonMock() throws UnRAVLException {
+        String responseBody = mockJson("{ 'error' : 'BAD REQUEST', 'httpStatusCode' : 400 }").toString();
+        mockServer
+                .expect(requestTo("/error.json"))
+                .andRespond(
+                        withBadRequest().body(responseBody).contentType(MediaType.APPLICATION_JSON));
+    }
+    
+
+
+    @Test
+    public void conflictResponse() throws UnRAVLException {
+
+        createConflictMock();
+        JUnitWrapper.runScriptsInDirectory(runtime, SRC_TEST_SCRIPTS_MOCK_FAIL,
+                "conflict.json");
+        mockServer.verify();
+    }
+
+    private void createConflictMock() throws UnRAVLException {
+        String responseBody = mockJson("{ 'error' : 'CONFLICT', 'httpStatusCode' : 409 }").toString();
+        mockServer
+                .expect(requestTo("/conflict.json"))
+                .andRespond(
+                        withStatus(HttpStatus.CONFLICT).body(responseBody).contentType(MediaType.APPLICATION_JSON));
+    }
+
     
 
 }

--- a/src/test/java/com/sas/unravl/test/TestScriptsWithMockServer.java
+++ b/src/test/java/com/sas/unravl/test/TestScriptsWithMockServer.java
@@ -36,7 +36,7 @@ public class TestScriptsWithMockServer extends TestBase {
 
     @Before
     public void createMockServer() {
-        restTemplate = new RestTemplate();
+        restTemplate = UnRAVLPlugins.newRestTemplate();
         setRestTemplate(restTemplate);
         mockServer = MockRestServiceServer.createServer(restTemplate);
     }

--- a/src/test/java/com/sas/unravl/test/TestScriptsWithMockServer.java
+++ b/src/test/java/com/sas/unravl/test/TestScriptsWithMockServer.java
@@ -2,6 +2,7 @@
 package com.sas.unravl.test;
 
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.sas.unravl.UnRAVLException;
@@ -80,6 +81,17 @@ public class TestScriptsWithMockServer extends TestBase {
                                         .toString(), MediaType.APPLICATION_JSON));
     }
 
+
+    private void createErrorJsonMock() throws UnRAVLException {
+        String responseBody = mockJson("{ 'error' : 'BAD REQUEST', 'httpStatusCode' : 400 }").toString();
+        mockServer
+                .expect(requestTo("/error.json"))
+                .andRespond(
+                        withBadRequest().body(responseBody).contentType(MediaType.APPLICATION_JSON));
+    }
+
+
+
     @Test
     public void helloText() throws UnRAVLException {
         createHelloTextMock();
@@ -121,5 +133,16 @@ public class TestScriptsWithMockServer extends TestBase {
                 withSuccess(new String(new byte[] { 0, 1, 2, 3, 4, 5, 6 }),
                         MediaType.APPLICATION_OCTET_STREAM));
     }
+    
+
+    @Test
+    public void errorResponse() throws UnRAVLException {
+
+        createErrorJsonMock();
+        JUnitWrapper.runScriptsInDirectory(runtime, SRC_TEST_SCRIPTS_MOCK_FAIL,
+                "errorJson.json");
+        mockServer.verify();
+    }
+    
 
 }

--- a/src/test/scripts/mock/fail/conflict.json
+++ b/src/test/scripts/mock/fail/conflict.json
@@ -1,0 +1,11 @@
+{
+   "name" : "expect an error object and 409 status",
+   "GET" : "/conflict.json",
+   "assert" :   [ 
+     { "doc" : "This test script should fail because the mock server returns an error response (JSON) and 409 COnflict at /error.json" },
+     { "json" :
+       { "error" : "CONFLICT", "httpStatusCode" : 409 }
+     },
+     { "status" : 409 }
+   ]
+}

--- a/src/test/scripts/mock/fail/errorJson.json
+++ b/src/test/scripts/mock/fail/errorJson.json
@@ -1,0 +1,11 @@
+{
+   "name" : "expect an error object and 400 status",
+   "GET" : "/error.json",
+   "assert" :   [ 
+     { "doc" : "This test script should fail because the mock server returns an error response (JSON) and 400 BAD REQUEST at /error.json" },
+     { "json" :
+       { "error" : "BAD REQUEST", "httpStatusCode" : 400 }
+     },
+     { "status" : 400 }
+   ]
+}


### PR DESCRIPTION
Using RestTemplate with the prior HttpClientFactory used JDK HttpUrlConnection which throws I/O exception when calling response.getBody() if the HTTP response is 4xx. This prevents UnRAVL from being able to bind the response body (Issue #69). This fixes that by using Apache HTTP Commons which dos not throw such exceptions.
