### PR TITLE
improve merging script auth data + .netrc data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'eclipse' // run './gradlew eclipse' to update Eclipse .classpath, then refresh Eclipse project
 
 group = 'com.sas'
-version = '1.3.0-SNAPSHOT'
+version = '1.3.1-SNAPSHOT'
 
 description = "Uniform REST API Validation Language"
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.sas</groupId>
    <artifactId>sas.unravl</artifactId>
-   <version>1.2.2-SNAPSHOT</version>
+   <version>1.3.1-SNAPSHOT</version>
    <description>Uniform REST API Validation Language  (UnRAVL) - a JSON DSL for validating REST APIs</description>
    <url>https://github.com/sassoftware/unravl</url>
    <inceptionYear>2014</inceptionYear>

--- a/src/main/java/com/sas/unravl/auth/AbstractCredentialsProvider.java
+++ b/src/main/java/com/sas/unravl/auth/AbstractCredentialsProvider.java
@@ -25,7 +25,8 @@ abstract public class AbstractCredentialsProvider implements
         CredentialsProvider {
 
     protected UnRAVLRuntime runtime;
-
+    protected ObjectNode auth;
+    
     public AbstractCredentialsProvider() {
         super();
     }
@@ -56,6 +57,7 @@ abstract public class AbstractCredentialsProvider implements
             boolean mock) throws IOException {
         if (mock)
             return mockCredentials();
+        this.auth = auth;
         String userName = credentialValue(auth, "login");
         if (userName == null)
             userName = credentialValue(auth, "user");
@@ -63,7 +65,7 @@ abstract public class AbstractCredentialsProvider implements
         return getHostCredentials(host, userName, password, mock);
     }
 
-    private String credentialValue(ObjectNode auth, String key) {
+    protected String credentialValue(ObjectNode auth, String key) {
         String val = Json.stringFieldOr(auth, key, null);
         return val == null ? null : runtime.expand(val);
     }
@@ -102,15 +104,14 @@ abstract public class AbstractCredentialsProvider implements
     }
 
     protected HostCredentials credentials(String login, String password) {
-        return new HostCredentials(runtime.expand(login),
-                runtime.expand(password));
+        return new HostCredentials(login, password);
     }
 
     protected HostCredentials credentials(String login, String password,
             String clientId, String clientSecret, String accessToken) {
-        return new OAuth2Credentials(runtime.expand(login),
-                runtime.expand(password), runtime.expand(clientId),
-                runtime.expand(clientSecret), runtime.expand(accessToken));
+        return new OAuth2Credentials(login,
+                password, clientId,
+                clientSecret, accessToken);
     }
 
 }

--- a/src/test/java/com/sas/unrav/auth/test/TestNetrcCredentials.java
+++ b/src/test/java/com/sas/unrav/auth/test/TestNetrcCredentials.java
@@ -2,6 +2,7 @@
 package com.sas.unrav.auth.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -99,7 +100,45 @@ public class TestNetrcCredentials {
             assertEquals(expectedClientId, oauth2.getClientId());
             assertEquals(expectedClientSecret, oauth2.getClientSecret());
         }
+        
+        if (expectedClientId != null) {
+        node = (ObjectNode) Json.parse(String.format("{ \"oauth2\" : \"\", \"login\": \"%s\", \"password\" : \"%s\" }", expectedUserName, expectedPassword));
+        cred = nc.getHostCredentials(hostName, node, false);
+        assertEquals(expectedUserName, cred.getUserName());
+        assertEquals(expectedPassword, cred.getPassword());
+        assertTrue(cred instanceof OAuth2Credentials); 
+        {
+            OAuth2Credentials oauth2 = (OAuth2Credentials) cred;
+            assertEquals(expectedClientId, oauth2.getClientId());
+            assertEquals(expectedClientSecret, oauth2.getClientSecret());
+        }
 
+
+        // verify that we use the password in the auth object, not in .netrc
+        node = (ObjectNode) Json.parse(String.format("{ \"oauth2\" : \"\", \"login\": \"%s\", \"password\" : \"override\" }", expectedUserName));
+        cred = nc.getHostCredentials(hostName, node, false);
+        assertEquals(expectedUserName, cred.getUserName());
+        assertEquals("override", cred.getPassword());
+        assertTrue(cred instanceof OAuth2Credentials); 
+        {
+            OAuth2Credentials oauth2 = (OAuth2Credentials) cred;
+            assertEquals(expectedClientId, oauth2.getClientId());
+            assertEquals(expectedClientSecret, oauth2.getClientSecret());
+        }
+        
+        // verify that we use the password , clientId, and secret in the auth object, not in .netrc
+        node = (ObjectNode) Json.parse(String.format("{ \"oauth2\" : \"\", \"login\": \"%s\", \"password\" : \"override\", \"clientId\": \"lClientId\", \"clientSecret\": \"lClientSecret\" }", expectedUserName ));
+        cred = nc.getHostCredentials(hostName, node, false);
+        assertEquals(expectedUserName, cred.getUserName());
+        assertEquals("override", cred.getPassword());
+        assertTrue(cred instanceof OAuth2Credentials); 
+        {
+            OAuth2Credentials oauth2 = (OAuth2Credentials) cred;
+            assertEquals("lClientId", oauth2.getClientId());
+            assertEquals("lClientSecret", oauth2.getClientSecret());
+        }
+
+        }
     }
 
     @AfterClass


### PR DESCRIPTION
This is a fix for #89 

If logon / password exist in the "auth" object, use them. For oauth2, use logon / password / clientId / clientSecret in the auth object, else the values in .netrc.
