### PR TITLE
V1.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'eclipse' // run './gradlew eclipse' to update Eclipse .classpath, then refresh Eclipse project
 
 group = 'com.sas'
-version = '1.3.1-SNAPSHOT'
+version = '1.3,1'
 
 description = "Uniform REST API Validation Language"
 

--- a/doc/Releases.md
+++ b/doc/Releases.md
@@ -1,5 +1,9 @@
 ## UnRAVL releases
 
+* [Release v1.3.1](https://github.com/sassoftware/unravl/releases/tag/v1.3.1)
+  * Add a prefix option to the href links extractor to resolve relative links
+  * Make Unix and Windows unravl CLI scripts more robust (running from a dev)
+  * Minor doc cleanup
 * [Release v1.2.1](https://github.com/sassoftware/unravl/releases/tag/v1.2.1)
   * Improved Cut/Copy/Paste, layout, threading, and other
     interactive mode improvements


### PR DESCRIPTION
This release adds a few minor features and  fixes a number of bugs. It also makes up for not making a v1.3.0 release.

Enhancements:
  * Add a prefix option to the href links extractor to resolve relative links

Bug fixes:
  * Make Unix and Windows unravl CLI scripts more robust (running from a dev)
  * minor doc cleanup